### PR TITLE
Enable LLM generation for definition queries

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -81,5 +81,14 @@ class TestHybridPipeline(unittest.TestCase):
         self.assertIsInstance(answer, str)
         self.assertTrue(len(answer) > 0)
 
+    def test_definition_answer_uses_llm(self):
+        processor = TextProcessor()
+        generator = AnswerGenerator(processor)
+        sentences = ["Evidence Theory is a mathematical framework for reasoning with uncertainty."]
+        with patch('backend.llm_generator.LLMGenerator.generate', return_value='LLM definition reply.'):
+            with patch.dict('os.environ', {'OPENAI_API_KEY': 'dummy'}):
+                answer = generator.generate('What is evidence theory?', sentences, 'definition', [])
+        self.assertEqual(answer, 'LLM definition reply.')
+
 if __name__ == '__main__':
     unittest.main()

--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -311,6 +311,14 @@ class AnswerGenerator:
                 return "\n".join(["Entities mentioned:", "- " + "\n- ".join(entities)])
 
         if query_type == "definition":
+            try:
+                llm = LLMGenerator()
+                answer = llm.generate(query, top_sentences[:4])
+                if answer:
+                    return answer
+            except Exception:
+                pass
+
             for s in top_sentences:
                 if " is " in s.lower():
                     return s


### PR DESCRIPTION
## Summary
- use LLMGenerator when answering definition-type queries
- add unit test for definition query LLM generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688920be2310832292adda1082714a4f