### PR TITLE
Fix OpenAI API usage

### DIFF
--- a/backend/llm_generator.py
+++ b/backend/llm_generator.py
@@ -1,7 +1,17 @@
 import os
 from typing import List
 
-import openai
+try:
+    from openai import OpenAI
+    OPENAI_V1 = True
+except Exception:  # pragma: no cover - fallback for older openai or missing pkg
+    try:
+        import openai  # type: ignore
+        OPENAI_V1 = False
+    except Exception:
+        OpenAI = None  # type: ignore
+        openai = None  # type: ignore
+        OPENAI_V1 = None
 
 
 class LLMGenerator:
@@ -14,7 +24,6 @@ class LLMGenerator:
     def generate(self, query: str, context_sentences: List[str]) -> str:
         if not self.api_key:
             raise ValueError("OPENAI_API_KEY not set")
-        openai.api_key = self.api_key
         context = " ".join(context_sentences[:4])
         messages = [
             {
@@ -29,5 +38,19 @@ class LLMGenerator:
                 "content": f"Context: {context}\n\nQuestion: {query}",
             },
         ]
-        response = openai.ChatCompletion.create(model=self.model, messages=messages)
-        return response.choices[0].message["content"].strip()
+        if OPENAI_V1 is True:
+            client = OpenAI(api_key=self.api_key)
+            try:
+                response = client.chat.completions.create(model=self.model, messages=messages)
+            except Exception as e:  # pragma: no cover - runtime errors
+                raise RuntimeError(f"OpenAI API call failed: {e}") from e
+            return response.choices[0].message.content.strip()
+        elif OPENAI_V1 is False:
+            openai.api_key = self.api_key
+            try:
+                response = openai.ChatCompletion.create(model=self.model, messages=messages)
+            except Exception as e:
+                raise RuntimeError(f"OpenAI API call failed: {e}") from e
+            return response.choices[0].message["content"].strip()
+        else:
+            raise ImportError("openai package is required to use LLMGenerator")

--- a/tests/test_llm_generator.py
+++ b/tests/test_llm_generator.py
@@ -1,0 +1,34 @@
+import os
+import types
+import sys
+import importlib
+from unittest.mock import MagicMock
+import pytest
+
+
+def test_generate_with_openai_v1(monkeypatch):
+    fake_openai_module = types.SimpleNamespace()
+    class FakeResponse:
+        def __init__(self):
+            self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content="Hi"))]
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = FakeResponse()
+    fake_openai_module.OpenAI = MagicMock(return_value=fake_client)
+    monkeypatch.setitem(sys.modules, 'openai', fake_openai_module)
+    import backend.llm_generator as llm
+    importlib.reload(llm)
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    generator = llm.LLMGenerator()
+    result = generator.generate("q", ["c"])
+    assert result == "Hi"
+    fake_openai_module.OpenAI.assert_called_once_with(api_key="key")
+    fake_client.chat.completions.create.assert_called_once()
+
+def test_generate_no_api_key(monkeypatch):
+    fake_openai_module = types.SimpleNamespace(OpenAI=MagicMock())
+    monkeypatch.setitem(sys.modules, 'openai', fake_openai_module)
+    import backend.llm_generator as llm
+    importlib.reload(llm)
+    generator = llm.LLMGenerator()
+    with pytest.raises(ValueError):
+        generator.generate("q", ["c"])


### PR DESCRIPTION
## Summary
- support openai>=1.0 client in `LLMGenerator`
- fallback to older openai API if present
- add unit tests covering `LLMGenerator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889241a58a08322b41873ae4efd890b