### PR TITLE
Improve entity query responses

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -90,5 +90,22 @@ class TestHybridPipeline(unittest.TestCase):
                 answer = generator.generate('What is evidence theory?', sentences, 'definition', [])
         self.assertEqual(answer, 'LLM definition reply.')
 
+    def test_entity_relationship_query_uses_llm(self):
+        processor = TextProcessor()
+        generator = AnswerGenerator(processor)
+        sentences = ["Alice and Bob collaborated on the project."]
+        with patch('backend.llm_generator.LLMGenerator.generate', return_value='Alice worked with Bob on the project.'):
+            with patch.dict('os.environ', {'OPENAI_API_KEY': 'dummy'}):
+                answer = generator.generate('Who did Alice collaborate with?', sentences, 'entity', [])
+        self.assertEqual(answer, 'Alice worked with Bob on the project.')
+
+    def test_entity_list_fallback(self):
+        processor = TextProcessor()
+        generator = AnswerGenerator(processor)
+        sentences = ["Charlie, Dana and Erin attended the meeting."]
+        answer = generator.generate('Who was mentioned?', sentences, 'entity', [])
+        self.assertIn('Entities mentioned:', answer)
+        self.assertIn('Charlie', answer)
+
 if __name__ == '__main__':
     unittest.main()

--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -148,6 +148,15 @@ class QueryClassifier:
             "companies",
             "partner",
             "collaborator",
+            "team",
+            "group",
+            "member",
+            "participant",
+            "contributor",
+            "stakeholder",
+            "department",
+            "division",
+            "institution",
         ]
 
         if any(word in q for word in entity_keywords):
@@ -303,12 +312,43 @@ class AnswerGenerator:
         top_sentences = self._select_sentences(sentences, query)
 
         if query_type == "entity":
+            relationship_keywords = [
+                "partner",
+                "collaborator",
+                "organization",
+                "company",
+                "involved",
+                "working",
+                "team",
+                "group",
+                "member",
+                "participant",
+                "contributor",
+                "stakeholder",
+                "entity",
+                "institution",
+                "department",
+                "division",
+            ]
+
+            if any(word in query.lower() for word in relationship_keywords):
+                try:
+                    llm = LLMGenerator()
+                    answer = llm.generate(query, top_sentences[:4])
+                    if answer:
+                        return answer
+                except Exception:
+                    pass
+
             entities: List[str] = []
             for s in top_sentences:
                 entities.extend(self.processor.extract_entities(s))
             entities = list(dict.fromkeys(entities))
             if entities:
-                return "\n".join(["Entities mentioned:", "- " + "\n- ".join(entities)])
+                return "\n".join([
+                    "Entities mentioned:",
+                    "- " + "\n- ".join(entities),
+                ])
 
         if query_type == "definition":
             try:


### PR DESCRIPTION
## Summary
- extend query classifier with more relationship keywords
- use LLM in entity handler when question targets relationships
- fallback to original entity list when LLM is not triggered
- add tests for new entity query behaviour

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68892e40a7a48322821a64957d84e6ad