### PR TITLE
Implement DeBERTa/Qwen routing

### DIFF
--- a/backend/qa_models.py
+++ b/backend/qa_models.py
@@ -1,0 +1,42 @@
+from typing import List, Dict, Any
+from .llm_generator import LLMGenerator
+
+class DeBERTaQA:
+    """Lightweight placeholder for a DeBERTa-based QA model."""
+
+    def __init__(self, config=None):
+        self.config = config
+
+    def answer(self, question: str, contexts: List[str]) -> Dict[str, Any]:
+        """Return an answer and confidence score."""
+        if not contexts:
+            return {"answer": "", "confidence": 0.0}
+
+        q_words = set(question.lower().split())
+        best_context = ""
+        best_score = 0
+        for ctx in contexts:
+            ctx_words = set(ctx.lower().split())
+            score = len(q_words & ctx_words)
+            if score > best_score:
+                best_score = score
+                best_context = ctx
+        confidence = min(1.0, best_score / (len(q_words) or 1))
+        return {"answer": best_context.strip(), "confidence": confidence}
+
+
+class QwenGenerator:
+    """Simple wrapper around an LLM generator representing Qwen."""
+
+    def __init__(self, config=None):
+        self.config = config
+
+    def generate(self, query: str, contexts: List[str]) -> Dict[str, Any]:
+        try:
+            llm = LLMGenerator()
+            answer = llm.generate(query, contexts)
+            confidence = 0.6
+        except Exception:
+            answer = ""
+            confidence = 0.0
+        return {"answer": answer, "confidence": confidence}


### PR DESCRIPTION
## Summary
- add `backend.qa_models` with simple `DeBERTaQA` and `QwenGenerator`
- route factual queries through DeBERTaQA with fallback to Qwen in `AnswerGenerator`
- incorporate the same routing logic in `HybridPipeline` processing methods
- store model and confidence metadata
- update tests for new routing logic

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688a947948b48322953a498a402c91c6