### PR TITLE
Update unit tests for new pipeline features

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,7 +14,8 @@ class TestIntegration(unittest.TestCase):
     def test_config_integration(self):
         try:
             from backend.config import Config
-            config = Config()
+            config = Config('config.yaml')
+            self.assertIn('Qwen', config.qwen.model_name)
             try:
                 from backend.health_check import HealthChecker
                 health_checker = HealthChecker(config)
@@ -58,6 +59,29 @@ class TestIntegration(unittest.TestCase):
             print("Integration possible")
         else:
             print("Limited integration")
+
+    def test_partnership_query_names(self):
+        try:
+            from weaviate_rag_pipeline_transformers import (
+                QueryClassifier,
+                TextProcessor,
+                AnswerGenerator,
+            )
+        except ImportError:
+            self.skipTest("RAG pipeline modules unavailable")
+
+        classifier = QueryClassifier()
+        query = "Which organizations are involved in the project?"
+        q_type = classifier.classify(query)
+        self.assertEqual(q_type, "partnership")
+
+        sentences = [
+            "The project partners include University of Skövde, Scania, Smart Eye and Viscando."
+        ]
+        processor = TextProcessor()
+        generator = AnswerGenerator(processor)
+        answer = generator.generate(query, sentences, "entity", [])
+        self.assertIn("Scania", answer)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_llm_generator.py
+++ b/tests/test_llm_generator.py
@@ -29,3 +29,14 @@ def test_deberta_no_contexts():
     de = qa_models.DeBERTaQA()
     result = de.answer('Any', [])
     assert result == {'answer': '', 'confidence': 0.0}
+
+
+def test_llm_generator_requires_api_key():
+    with patch.dict('os.environ', {}, clear=True):
+        gen = qa_models.LLMGenerator()
+        try:
+            gen.generate('q', ['ctx'])
+        except ValueError as e:
+            assert 'OPENAI_API_KEY' in str(e)
+        else:
+            assert False, 'ValueError not raised'


### PR DESCRIPTION
## Summary
- provide lightweight dependency stubs in `test_pipeline`
- expand pipeline unit tests for query classifier and boosting logic
- check API key requirement in `test_llm_generator`
- load configuration file in integration test and verify partnership query results

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688b685615b08322a38d0d94b6b03ff6