### PR TITLE
Extend config parsing across modules

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -45,6 +45,116 @@ class HybridConfig:
     confidence_threshold: float = 0.75
     enable_qwen_fallback: bool = True
 
+@dataclass
+class OpenAIConfig:
+    enabled: bool = False
+    api_key: str = ""
+    model: str = "gpt-3.5-turbo"
+    fallback_only: bool = True
+
+@dataclass
+class RetrievalConfig:
+    default_top_k: int = 5
+    partnership_top_k: int = 5
+    factual_top_k: int = 5
+    similarity_threshold: float = 0.3
+    enable_section_reranking: bool = True
+    section_name_boost: float = 1.0
+    deberta_max_context: int = 400
+    qwen_max_context: int = 800
+
+@dataclass
+class PromptingConfig:
+    context_instructions: dict = None
+    qwen_system_prompt: str = ""
+    deberta_instruction: str = ""
+
+    def __post_init__(self):
+        if self.context_instructions is None:
+            self.context_instructions = {}
+
+@dataclass
+class HardwareConfig:
+    use_gpu: bool = False
+    gpu_memory_fraction: float = 0.0
+    num_threads: int = 1
+    max_model_memory: str = ""
+    enable_model_offloading: bool = False
+    enable_response_cache: bool = False
+    cache_size: int = 0
+    cache_ttl: int = 0
+
+@dataclass
+class ChunkProcessingConfig:
+    add_section_markers: bool = True
+    add_metadata_context: bool = True
+    max_context_length: int = 100
+    section_patterns: list = None
+
+    def __post_init__(self):
+        if self.section_patterns is None:
+            self.section_patterns = []
+
+@dataclass
+class QueryProcessingConfig:
+    expand_synonyms: bool = False
+    synonyms: dict = None
+
+    def __post_init__(self):
+        if self.synonyms is None:
+            self.synonyms = {}
+
+@dataclass
+class DomainDetectionConfig:
+    enabled: bool = False
+    domain_keywords: dict = None
+
+    def __post_init__(self):
+        if self.domain_keywords is None:
+            self.domain_keywords = {}
+
+@dataclass
+class LoggingConfig:
+    log_chunk_retrieval: bool = False
+    log_section_matching: bool = False
+    log_query_classification: bool = False
+    log_model_selection: bool = False
+    log_confidence_scores: bool = False
+    log_performance_metrics: bool = False
+    level: str = "INFO"
+    file: str = "logs/rag_system.log"
+    track_model_performance: bool = False
+    save_response_analytics: bool = False
+
+@dataclass
+class MultiModelConfig:
+    enabled: bool = True
+    primary_llm: str = "qwen"
+    qa_model: str = "deberta"
+    model_selection: dict = None
+    confidence_thresholds: dict = None
+    ensemble_mode: str = ""
+    combine_answers: bool = False
+    timeout_seconds: int = 45
+    max_retries: int = 2
+    parallel_inference: bool = False
+    offload_unused_models: bool = False
+    max_memory_usage: str = ""
+
+    def __post_init__(self):
+        if self.model_selection is None:
+            self.model_selection = {}
+        if self.confidence_thresholds is None:
+            self.confidence_thresholds = {}
+
+@dataclass
+class SectionPrioritiesConfig:
+    queries: dict = None
+
+    def __post_init__(self):
+        if self.queries is None:
+            self.queries = {}
+
 class Config:
     """Central configuration management with YAML and environment support."""
 
@@ -61,6 +171,17 @@ class Config:
         self.deberta = DeBERTaConfig()
         self.qwen = QwenConfig()
         self.hybrid = HybridConfig()
+        self.openai = OpenAIConfig()
+        self.retrieval = RetrievalConfig()
+        self.prompting = PromptingConfig()
+        self.hardware = HardwareConfig()
+        self.chunk_processing = ChunkProcessingConfig()
+        self.query_processing = QueryProcessingConfig()
+        self.domain_detection = DomainDetectionConfig()
+        self.logging = LoggingConfig()
+        self.multi_model = MultiModelConfig()
+        self.section_priorities = SectionPrioritiesConfig()
+        self.semantic_metadata = {}
 
         # Store config path
         self.config_path = config_path
@@ -92,7 +213,16 @@ class Config:
                 'embedding': self.embedding,
                 'deberta': self.deberta,
                 'qwen': self.qwen,
-                'hybrid': self.hybrid
+                'hybrid': self.hybrid,
+                'openai': self.openai,
+                'retrieval': self.retrieval,
+                'prompting': self.prompting,
+                'hardware': self.hardware,
+                'chunk_processing': self.chunk_processing,
+                'query_processing': self.query_processing,
+                'domain_detection': self.domain_detection,
+                'logging': self.logging,
+                'multi_model': self.multi_model
             }
 
             for config_name, config_obj in config_mappings.items():
@@ -101,6 +231,12 @@ class Config:
                     for key, value in config_data.items():
                         if hasattr(config_obj, key):
                             setattr(config_obj, key, value)
+
+            # Non-dataclass mappings
+            if 'section_priorities' in data:
+                self.section_priorities.queries = data.get('section_priorities', {})
+            if 'semantic_metadata' in data:
+                self.semantic_metadata = data.get('semantic_metadata', {})
 
         except Exception as e:
             print(f"Warning: Could not load config from {path}: {e}")
@@ -120,6 +256,20 @@ class Config:
             self.qwen.api_key = os.getenv('QWEN_API_KEY')
         if os.getenv('QWEN_API_URL'):
             self.qwen.api_url = os.getenv('QWEN_API_URL')
+
+        # Hardware overrides
+        if os.getenv('USE_GPU'):
+            self.hardware.use_gpu = os.getenv('USE_GPU').lower() == 'true'
+        if os.getenv('GPU_MEMORY_FRACTION'):
+            try:
+                self.hardware.gpu_memory_fraction = float(os.getenv('GPU_MEMORY_FRACTION'))
+            except ValueError:
+                pass
+        if os.getenv('NUM_THREADS'):
+            try:
+                self.hardware.num_threads = int(os.getenv('NUM_THREADS'))
+            except ValueError:
+                pass
 
     def validate(self) -> List[str]:
         """Validate configuration and return list of errors/warnings."""
@@ -165,7 +315,9 @@ class Config:
             'weaviate_url': self.weaviate.url,
             'embedding_model': self.embedding.model_name,
             'deberta_model': self.deberta.model_name,
-            'qwen_configured': bool(self.qwen.api_key)
+            'qwen_configured': bool(self.qwen.api_key),
+            'retrieval_default_top_k': self.retrieval.default_top_k,
+            'use_gpu': self.hardware.use_gpu
         }
 
 # Test the configuration system

--- a/processing/hybrid_pipeline.py
+++ b/processing/hybrid_pipeline.py
@@ -58,13 +58,15 @@ class HybridPipeline:
 
     def _route_models(self, question: str, contexts: List[str]) -> Dict[str, Any]:
         if self._is_factual(question):
+            qa_contexts = contexts[: self.config.retrieval.deberta_max_context]
             qa = DeBERTaQA(self.config)
-            res = qa.answer(question, contexts)
+            res = qa.answer(question, qa_contexts)
             if res.get("confidence", 0) >= self.config.deberta.confidence_threshold and res.get("answer"):
                 res["model"] = "deberta"
                 return res
+        gen_contexts = contexts[: self.config.retrieval.qwen_max_context]
         gen = QwenGenerator(self.config)
-        res = gen.generate(question, contexts)
+        res = gen.generate(question, gen_contexts)
         res["model"] = "qwen"
         return res
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,14 @@ class TestConfig(unittest.TestCase):
         self.assertIsInstance(config.chunk_size, int)
         self.assertGreater(config.chunk_size, 0)
 
+        # New sub-configs
+        self.assertTrue(hasattr(config, 'retrieval'))
+        self.assertTrue(hasattr(config.retrieval, 'default_top_k'))
+        self.assertTrue(hasattr(config, 'hardware'))
+
+        self.assertIsInstance(config.retrieval.default_top_k, int)
+        self.assertIsInstance(config.hardware.use_gpu, bool)
+
     def test_validation(self):
         """Test configuration validation."""
         config = Config("nonexistent.yaml")


### PR DESCRIPTION
## Summary
- expand `backend/config.py` to load all sections from `config.yaml`
- expose retrieval, hardware, prompting and other settings
- use `Config` instance inside `weaviate_rag_pipeline_transformers.py`
- route model contexts in `HybridPipeline` based on retrieval config
- update tests for new config attributes

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688b60618d9483229d871547512ab062