### PR TITLE
Switch QA models to HF

### DIFF
--- a/backend/qa_models.py
+++ b/backend/qa_models.py
@@ -1,42 +1,180 @@
+"""Model wrappers for extractive and generative QA."""
+
 from typing import List, Dict, Any
+
+try:  # Optional torch dependency
+    import torch
+except Exception:  # pragma: no cover - allow missing torch
+    torch = None
+from transformers import (
+    AutoModelForQuestionAnswering,
+    AutoTokenizer,
+    AutoModelForCausalLM,
+)
+
 from .llm_generator import LLMGenerator
+from .config import Config
 
 class DeBERTaQA:
-    """Lightweight placeholder for a DeBERTa-based QA model."""
+    """Extractive QA using a DeBERTa model from HuggingFace."""
 
-    def __init__(self, config=None):
-        self.config = config
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+        if torch is None:
+            self.available = False
+            self.device = "cpu"
+            self.model = None
+            self.tokenizer = None
+            return
 
-    def answer(self, question: str, contexts: List[str]) -> Dict[str, Any]:
-        """Return an answer and confidence score."""
+        self.device = self._select_device()
+        model_name = self.config.deberta.model_name
+        cache_dir = getattr(self.config.deberta, "cache_dir", None)
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
+            self.model = AutoModelForQuestionAnswering.from_pretrained(model_name, cache_dir=cache_dir)
+            self.model.to(self.device)
+            self.available = True
+        except Exception:  # pragma: no cover - runtime/installation issues
+            self.available = False
+            self.model = None
+            self.tokenizer = None
+
+    def _select_device(self) -> str:
+        if torch is None:
+            return "cpu"
+
+        requested = getattr(self.config.deberta, "device", "auto")
+        if requested == "cpu":
+            return "cpu"
+        if requested == "cuda" and torch.cuda.is_available():
+            return "cuda"
+        if requested == "auto":
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        return "cpu"
+
+    def _fallback_answer(self, question: str, contexts: List[str]) -> Dict[str, Any]:
         if not contexts:
             return {"answer": "", "confidence": 0.0}
 
         q_words = set(question.lower().split())
-        best_context = ""
-        best_score = 0
-        for ctx in contexts:
-            ctx_words = set(ctx.lower().split())
-            score = len(q_words & ctx_words)
-            if score > best_score:
-                best_score = score
-                best_context = ctx
-        confidence = min(1.0, best_score / (len(q_words) or 1))
-        return {"answer": best_context.strip(), "confidence": confidence}
+        best_ctx = max(
+            contexts,
+            key=lambda c: len(q_words & set(c.lower().split())),
+            default="",
+        )
+        score = len(q_words & set(best_ctx.lower().split()))
+        confidence = min(1.0, score / (len(q_words) or 1))
+        return {"answer": best_ctx.strip(), "confidence": confidence}
+
+    def answer(self, question: str, contexts: List[str]) -> Dict[str, Any]:
+        if not contexts:
+            return {"answer": "", "confidence": 0.0}
+
+        if not self.available:
+            return self._fallback_answer(question, contexts)
+
+        context = " ".join(contexts)
+        inputs = self.tokenizer(
+            question,
+            context,
+            return_tensors="pt",
+            truncation=True,
+            max_length=getattr(self.config.deberta, "max_length", 512),
+        )
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+
+        start_logits = outputs.start_logits[0]
+        end_logits = outputs.end_logits[0]
+        max_len = getattr(self.config.deberta, "max_answer_length", 30)
+        start_idx, end_idx = 0, 0
+        max_score = float("-inf")
+        for i in range(len(start_logits)):
+            for j in range(i, min(i + max_len, len(end_logits))):
+                score = start_logits[i] + end_logits[j]
+                if score > max_score:
+                    start_idx, end_idx, max_score = i, j, score
+
+        answer_ids = inputs["input_ids"][0][start_idx : end_idx + 1]
+        answer = self.tokenizer.decode(answer_ids, skip_special_tokens=True).strip()
+
+        start_probs = torch.softmax(start_logits, dim=0)
+        end_probs = torch.softmax(end_logits, dim=0)
+        confidence = float((start_probs[start_idx] * end_probs[end_idx]).item())
+
+        return {"answer": answer, "confidence": confidence}
 
 
 class QwenGenerator:
-    """Simple wrapper around an LLM generator representing Qwen."""
+    """Generative model wrapper for the Qwen LLM."""
 
-    def __init__(self, config=None):
-        self.config = config
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+        if torch is None:
+            self.available = False
+            self.device = "cpu"
+            self.model = None
+            self.tokenizer = None
+            return
+
+        self.device = self._select_device()
+        model_name = self.config.qwen.model_name
+        cache_dir = getattr(self.config.qwen, "cache_dir", None)
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                model_name,
+                trust_remote_code=getattr(self.config.qwen, "trust_remote_code", False),
+                cache_dir=cache_dir,
+            )
+            self.model = AutoModelForCausalLM.from_pretrained(
+                model_name,
+                trust_remote_code=getattr(self.config.qwen, "trust_remote_code", False),
+                cache_dir=cache_dir,
+            )
+            self.model.to(self.device)
+            self.available = True
+        except Exception:  # pragma: no cover - runtime/installation issues
+            self.available = False
+            self.model = None
+            self.tokenizer = None
+
+    def _select_device(self) -> str:
+        if torch is None:
+            return "cpu"
+
+        requested = getattr(self.config.qwen, "device", "auto")
+        if requested == "cpu":
+            return "cpu"
+        if requested == "cuda" and torch.cuda.is_available():
+            return "cuda"
+        if requested == "auto":
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        return "cpu"
 
     def generate(self, query: str, contexts: List[str]) -> Dict[str, Any]:
+        context = " ".join(contexts)
+
+        if self.available:
+            prompt = f"{query}\n\n{context}"
+            inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+            with torch.no_grad():
+                output = self.model.generate(
+                    **inputs,
+                    max_new_tokens=getattr(self.config.qwen, "max_new_tokens", 128),
+                    do_sample=getattr(self.config.qwen, "do_sample", False),
+                    temperature=getattr(self.config.qwen, "temperature", 0.7),
+                )
+            answer = self.tokenizer.decode(output[0][inputs["input_ids"].shape[1]:], skip_special_tokens=True).strip()
+            confidence = 0.6
+            return {"answer": answer, "confidence": confidence}
+
+        # Fallback to OpenAI-based LLMGenerator if local model unavailable
         try:
             llm = LLMGenerator()
             answer = llm.generate(query, contexts)
-            confidence = 0.6
+            return {"answer": answer, "confidence": 0.6}
         except Exception:
-            answer = ""
-            confidence = 0.0
-        return {"answer": answer, "confidence": confidence}
+            return {"answer": "", "confidence": 0.0}

--- a/tests/test_llm_generator.py
+++ b/tests/test_llm_generator.py
@@ -2,30 +2,56 @@ from unittest.mock import patch
 from backend import qa_models
 
 
-def test_qwen_generator_success():
-    with patch('backend.qa_models.LLMGenerator.generate', return_value='hello') as mock_llm:
+class DummyTokenizer:
+    def __call__(self, *args, **kwargs):
+        import torch
+        return {"input_ids": torch.tensor([[0, 1, 2]]), "attention_mask": torch.tensor([[1, 1, 1]])}
+
+    def decode(self, ids, skip_special_tokens=True):
+        return "dummy"
+
+
+class DummyDebertaModel:
+    def to(self, device):
+        pass
+
+    def __call__(self, **inputs):
+        import torch
+        start = torch.tensor([[0.0, 4.0, 0.0]])
+        end = torch.tensor([[0.0, 0.0, 4.0]])
+        return type("O", (), {"start_logits": start, "end_logits": end})
+
+
+class DummyQwenModel:
+    def to(self, device):
+        pass
+
+    def generate(self, **kwargs):
+        return kwargs["input_ids"]
+
+
+def test_qwen_generator_fallback():
+    with patch("transformers.AutoModelForCausalLM.from_pretrained", side_effect=OSError), \
+         patch("backend.qa_models.LLMGenerator.generate", return_value="hello") as mock_llm:
         gen = qa_models.QwenGenerator()
-        result = gen.generate('q', ['ctx'])
-    assert result == {'answer': 'hello', 'confidence': 0.6}
-    mock_llm.assert_called_once_with('q', ['ctx'])
+        result = gen.generate("q", ["ctx"])
+    assert result == {"answer": "hello", "confidence": 0.6}
+    mock_llm.assert_called_once_with("q", ["ctx"])
 
 
-def test_qwen_generator_failure():
-    with patch('backend.qa_models.LLMGenerator.generate', side_effect=RuntimeError):
-        gen = qa_models.QwenGenerator()
-        result = gen.generate('q', ['ctx'])
-    assert result == {'answer': '', 'confidence': 0.0}
+def test_deberta_answer_from_model():
+    with patch("transformers.AutoTokenizer.from_pretrained", return_value=DummyTokenizer()), \
+         patch("transformers.AutoModelForQuestionAnswering.from_pretrained", return_value=DummyDebertaModel()):
+        de = qa_models.DeBERTaQA()
+        res = de.answer("q", ["ctx"])
+    assert res["answer"] == "dummy"
+    assert 0.0 <= res["confidence"] <= 1.0
 
 
-def test_deberta_answer_selects_best_context():
-    de = qa_models.DeBERTaQA()
-    result = de.answer('Who is Alice', ['Bob went home', 'Alice went home'])
-    assert result['answer'] == 'Alice went home'
-    # q_words = {"who","is","alice"}; best_score = 1; len(q_words)=3 => conf=1/3
-    assert abs(result['confidence'] - (1/3)) < 0.0001
-
-
-def test_deberta_no_contexts():
-    de = qa_models.DeBERTaQA()
-    result = de.answer('Any', [])
-    assert result == {'answer': '', 'confidence': 0.0}
+def test_deberta_fallback_no_model():
+    with patch("transformers.AutoModelForQuestionAnswering.from_pretrained", side_effect=OSError), \
+         patch("transformers.AutoTokenizer.from_pretrained", side_effect=OSError):
+        de = qa_models.DeBERTaQA()
+        res = de.answer("who", ["Alice went home"])
+    assert res["answer"] == "Alice went home"
+    assert res["confidence"] > 0


### PR DESCRIPTION
## Summary
- implement DeBERTaQA via transformers with confidence from softmax
- use transformers to load Qwen2.5-7B Instruct with fallbacks
- update unit tests for new behaviour

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688b5ea5ce708322904589938a34bede