### PR TITLE
Improve model routing and config

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -3,7 +3,7 @@ Configuration management for the modular RAG system.
 Centralizes settings and replaces hardcoded values from existing scripts.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, List
 import os
 from pathlib import Path
@@ -45,6 +45,17 @@ class HybridConfig:
     confidence_threshold: float = 0.75
     enable_qwen_fallback: bool = True
 
+
+@dataclass
+class MultiModelConfig:
+    """Configuration for multi-model selection and thresholds."""
+
+    enabled: bool = True
+    model_selection: dict = field(default_factory=dict)
+    confidence_thresholds: dict = field(default_factory=dict)
+    primary_llm: str = "qwen"
+    qa_model: str = "deberta"
+
 class Config:
     """Central configuration management with YAML and environment support."""
 
@@ -61,6 +72,7 @@ class Config:
         self.deberta = DeBERTaConfig()
         self.qwen = QwenConfig()
         self.hybrid = HybridConfig()
+        self.multi_model = MultiModelConfig()
 
         # Store config path
         self.config_path = config_path
@@ -92,7 +104,8 @@ class Config:
                 'embedding': self.embedding,
                 'deberta': self.deberta,
                 'qwen': self.qwen,
-                'hybrid': self.hybrid
+                'hybrid': self.hybrid,
+                'multi_model': self.multi_model,
             }
 
             for config_name, config_obj in config_mappings.items():

--- a/backend/qa_models.py
+++ b/backend/qa_models.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from .llm_generator import LLMGenerator
 
 class DeBERTaQA:
@@ -31,10 +31,17 @@ class QwenGenerator:
     def __init__(self, config=None):
         self.config = config
 
-    def generate(self, query: str, contexts: List[str]) -> Dict[str, Any]:
+    def generate(
+        self,
+        query: str,
+        contexts: List[str],
+        instruction: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Generate an answer using the underlying LLM."""
         try:
             llm = LLMGenerator()
-            answer = llm.generate(query, contexts)
+            full_query = f"{instruction}\n\n{query}" if instruction else query
+            answer = llm.generate(full_query, contexts)
             confidence = 0.6
         except Exception:
             answer = ""

--- a/processing/hybrid_pipeline.py
+++ b/processing/hybrid_pipeline.py
@@ -56,17 +56,61 @@ class HybridPipeline:
         q = question.lower()
         return q.startswith("what is") or q.startswith("define") or "definition" in q
 
+    def _is_partnership(self, question: str) -> bool:
+        q = question.lower()
+        keywords = [
+            "partner",
+            "collaborator",
+            "organization",
+            "company",
+            "team",
+            "consortium",
+            "stakeholder",
+            "member",
+            "involved",
+            "working",
+        ]
+        return any(k in q for k in keywords)
+
     def _route_models(self, question: str, contexts: List[str]) -> Dict[str, Any]:
-        if self._is_factual(question):
-            qa = DeBERTaQA(self.config)
-            res = qa.answer(question, contexts)
-            if res.get("confidence", 0) >= self.config.deberta.confidence_threshold and res.get("answer"):
+        mm = getattr(self.config, "multi_model", None)
+        model_lists = mm.model_selection if mm else {}
+
+        if self._is_partnership(question):
+            order = model_lists.get("partnership_queries", ["qwen"])
+        elif self._is_factual(question):
+            order = model_lists.get("factual_queries", ["deberta", "qwen"])
+        else:
+            order = model_lists.get("general_queries", ["qwen"])
+
+        thresholds = mm.confidence_thresholds if mm else {}
+        deberta_min = thresholds.get("deberta_minimum", self.config.deberta.confidence_threshold)
+        qwen_min = thresholds.get("qwen_minimum", 0.0)
+
+        last_result: Dict[str, Any] = {"answer": "", "confidence": 0.0, "model": None}
+        for model_name in order:
+            if model_name == "deberta":
+                qa = DeBERTaQA(self.config)
+                res = qa.answer(question, contexts)
                 res["model"] = "deberta"
-                return res
-        gen = QwenGenerator(self.config)
-        res = gen.generate(question, contexts)
-        res["model"] = "qwen"
-        return res
+                last_result = res
+                if res.get("confidence", 0) >= deberta_min and res.get("answer"):
+                    return res
+            elif model_name == "qwen":
+                instruction = None
+                if self._is_partnership(question):
+                    try:
+                        instruction = self.config.prompting["context_instructions"]["partnership"]
+                    except Exception:
+                        instruction = None
+                gen = QwenGenerator(self.config)
+                res = gen.generate(question, contexts, instruction=instruction)
+                res["model"] = "qwen"
+                last_result = res
+                if res.get("confidence", 0) >= qwen_min:
+                    return res
+
+        return last_result
 
     def initialize(self) -> bool:
         """Initialize all available pipeline components."""


### PR DESCRIPTION
## Summary
- support multi model configuration
- allow Qwen generator to accept optional prompt instructions
- route queries in `HybridPipeline` using config-driven rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6721255483228afc958cc07d6ad9