### PR TITLE
Add Neo4j service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,24 @@ services:
       production8_weaviate-net:
         aliases:
           - t2v-transformers
+  neo4j:
+    image: neo4j:community
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      - NEO4J_AUTH=neo4j/password
+    volumes:
+      - neo4j_data:/data
+    networks:
+      production8_weaviate-net:
+        aliases:
+          - neo4j
 networks:
   production8_weaviate-net:
     driver: bridge
     ipam:
       config:
         - subnet: "172.29.0.0/16"
+volumes:
+  neo4j_data:


### PR DESCRIPTION
## Summary
- add a Neo4j container alongside Weaviate
- mount a neo4j_data volume for persistence

## Testing
- `pytest -q` *(fails: SyntaxError in backend/llm_generator.py)*

------
https://chatgpt.com/codex/tasks/task_e_688d23c7550883229354482c1637ea59