### PR TITLE
Add knowledge graph tests

### DIFF
--- a/backend/knowledge_graph.py
+++ b/backend/knowledge_graph.py
@@ -1,0 +1,39 @@
+from typing import List, Tuple
+from neo4j import Driver
+
+
+def build_knowledge_graph(triples: List[Tuple[str, str, str]], driver: Driver) -> None:
+    """Create nodes and relationships in Neo4j from triples."""
+    with driver.session() as session:
+        for subj, rel, obj in triples:
+            session.run("MERGE (a:Entity {name: $name})", name=subj)
+            session.run("MERGE (b:Entity {name: $name})", name=obj)
+            session.run(
+                "MATCH (a:Entity {name: $subj}) "
+                "MATCH (b:Entity {name: $obj}) "
+                f"MERGE (a)-[:{rel.upper()}]->(b)",
+                subj=subj,
+                obj=obj,
+            )
+
+
+def query_knowledge_graph(entity: str, driver: Driver) -> List[str]:
+    """Return connected entity names for the given entity."""
+    with driver.session() as session:
+        result = session.run(
+            "MATCH (a:Entity {name: $name})-->(b:Entity) RETURN b.name AS name",
+            name=entity,
+        )
+        return [record["name"] for record in result]
+
+
+def hybrid_retrieval(query: str, vector_results: List[str], driver: Driver, top_k: int = 5) -> List[str]:
+    """Combine graph query results with vector search results and deduplicate."""
+    graph_results = query_knowledge_graph(query, driver)
+    combined = []
+    for item in graph_results + vector_results:
+        if item not in combined:
+            combined.append(item)
+        if len(combined) >= top_k:
+            break
+    return combined

--- a/backend/llm_generator.py
+++ b/backend/llm_generator.py
@@ -10,7 +10,6 @@ except Exception:  # pragma: no cover - anthropic optional
 class LLMGenerator:
     """Simple wrapper around the Claude API."""
 
-
     def __init__(
         self,
         model: str = "claude-3-5-haiku-20241022",
@@ -19,10 +18,6 @@ class LLMGenerator:
         temperature: float = 0.1,
     ) -> None:
         self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
-
-    def __init__(self, model: str = "claude-3-5-haiku-20241022"):
-        self.api_key = os.getenv("ANTHROPIC_API_KEY")
-
         self.model = model
         self.max_tokens = max_tokens
         self.temperature = temperature
@@ -40,7 +35,6 @@ class LLMGenerator:
             raise ImportError("anthropic package is required to use LLMGenerator")
         client = Anthropic(api_key=self.api_key)
         context = " ".join(context_sentences[:8])
-
         user_content = f"Context:\n{context}\n\nQuestion:\n{query}"
         if instruction:
             user_content = f"{instruction}\n\n{user_content}"
@@ -52,16 +46,6 @@ class LLMGenerator:
                 temperature=self.temperature,
                 messages=messages,
                 system=system_prompt,
-
-        messages = [
-            {"role": "user", "content": f"Context: {context}\n\nQuestion: {query}"}
-        ]
-        try:  # pragma: no cover - runtime errors
-            response = client.messages.create(
-                model=self.model,
-                max_tokens=512,
-                messages=messages,
-
             )
             return "".join(block.text for block in response.content).strip()
         except Exception as e:  # pragma: no cover - runtime errors

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -14,6 +14,7 @@ def run_all_tests():
 
     loader = unittest.TestLoader()
     start_dir = Path(__file__).parent
+    # Discover all tests including new knowledge graph tests
     suite = loader.discover(start_dir, pattern='test_*.py')
 
     test_count = suite.countTestCases()

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import Mock, call, patch
+
+from backend.knowledge_graph import (
+    build_knowledge_graph,
+    query_knowledge_graph,
+    hybrid_retrieval,
+)
+
+
+class TestKnowledgeGraph(unittest.TestCase):
+    def test_build_knowledge_graph_calls(self):
+        mock_session = Mock()
+        mock_context = Mock(__enter__=Mock(return_value=mock_session), __exit__=Mock(return_value=None))
+        mock_driver = Mock()
+        mock_driver.session.return_value = mock_context
+
+        triples = [("Alice", "knows", "Bob")]
+        build_knowledge_graph(triples, mock_driver)
+
+        self.assertIn(
+            call("MERGE (a:Entity {name: $name})", name="Alice"),
+            mock_session.run.call_args_list,
+        )
+        self.assertIn(
+            call("MERGE (b:Entity {name: $name})", name="Bob"),
+            mock_session.run.call_args_list,
+        )
+        self.assertTrue(
+            any("MERGE (a)-[:KNOWS]->(b)" in c.args[0] for c in mock_session.run.call_args_list)
+        )
+
+    def test_query_knowledge_graph(self):
+        mock_session = Mock()
+        mock_session.run.return_value = [
+            {"name": "Bob"},
+            {"name": "Carol"},
+        ]
+        mock_context = Mock(__enter__=Mock(return_value=mock_session), __exit__=Mock(return_value=None))
+        mock_driver = Mock()
+        mock_driver.session.return_value = mock_context
+
+        results = query_knowledge_graph("Alice", mock_driver)
+
+        self.assertEqual(results, ["Bob", "Carol"])
+        mock_session.run.assert_called_with(
+            "MATCH (a:Entity {name: $name})-->(b:Entity) RETURN b.name AS name",
+            name="Alice",
+        )
+
+    def test_hybrid_retrieval_merge(self):
+        mock_driver = Mock()
+        with patch("backend.knowledge_graph.query_knowledge_graph", return_value=["X", "Y"]):
+            results = hybrid_retrieval("query", ["Y", "Z"], mock_driver, top_k=10)
+        self.assertEqual(results, ["X", "Y", "Z"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a small Neo4j helper module
- fix `LLMGenerator` syntax for tests
- add tests covering knowledge graph behaviour
- ensure test runner discovers new tests

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688d1c38d2e88322a63f4ebd5a0e7a4e