### PR TITLE
Add knowledge graph CLI modes

### DIFF
--- a/backend/llm_generator.py
+++ b/backend/llm_generator.py
@@ -8,8 +8,7 @@ except Exception:  # pragma: no cover - anthropic optional
 
 
 class LLMGenerator:
-    """Simple wrapper around the Claude API."""
-
+    """Lightweight wrapper for the Anthropic Claude API."""
 
     def __init__(
         self,
@@ -19,10 +18,6 @@ class LLMGenerator:
         temperature: float = 0.1,
     ) -> None:
         self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
-
-    def __init__(self, model: str = "claude-3-5-haiku-20241022"):
-        self.api_key = os.getenv("ANTHROPIC_API_KEY")
-
         self.model = model
         self.max_tokens = max_tokens
         self.temperature = temperature
@@ -38,13 +33,14 @@ class LLMGenerator:
             raise ValueError("ANTHROPIC_API_KEY not set")
         if Anthropic is None:
             raise ImportError("anthropic package is required to use LLMGenerator")
+
         client = Anthropic(api_key=self.api_key)
         context = " ".join(context_sentences[:8])
-
         user_content = f"Context:\n{context}\n\nQuestion:\n{query}"
         if instruction:
             user_content = f"{instruction}\n\n{user_content}"
         messages = [{"role": "user", "content": user_content}]
+
         try:  # pragma: no cover - runtime errors
             response = client.messages.create(
                 model=self.model,
@@ -52,16 +48,6 @@ class LLMGenerator:
                 temperature=self.temperature,
                 messages=messages,
                 system=system_prompt,
-
-        messages = [
-            {"role": "user", "content": f"Context: {context}\n\nQuestion: {query}"}
-        ]
-        try:  # pragma: no cover - runtime errors
-            response = client.messages.create(
-                model=self.model,
-                max_tokens=512,
-                messages=messages,
-
             )
             return "".join(block.text for block in response.content).strip()
         except Exception as e:  # pragma: no cover - runtime errors

--- a/backend/qa_models.py
+++ b/backend/qa_models.py
@@ -1,23 +1,20 @@
 """Claude-based QA models for the RAG system."""
 
 from typing import List, Dict, Any, Optional
-
 import logging
+
 from .llm_generator import LLMGenerator
 from .config import Config
-
 
 logger = logging.getLogger(__name__)
 
 
-
 class ClaudeQA:
-    """Simple wrapper that uses Claude for answer generation."""
+    """Thin wrapper around LLMGenerator for question answering."""
 
     def __init__(self, config: Optional[Config] = None) -> None:
         self.config = config or Config()
         model_name = getattr(self.config.claude, "model_name", "claude-3-5-haiku-20241022")
-
         self.generator = LLMGenerator(
             model=model_name,
             api_key=self.config.claude.api_key,
@@ -28,36 +25,23 @@ class ClaudeQA:
             "You are a helpful assistant that summarizes partnership and collaborator information from provided context."
         )
 
-        self.generator = LLMGenerator(model=model_name)
-
-
     def generate(
         self,
         query: str,
         contexts: List[str],
         instruction: Optional[str] = None,
     ) -> Dict[str, Any]:
-
-        prompt_instruction = instruction
         try:
             answer = self.generator.generate(
                 query,
                 contexts,
-                instruction=prompt_instruction,
+                instruction=instruction,
                 system_prompt=self.system_prompt,
             )
             return {"answer": answer, "confidence": 0.6}
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - runtime errors
             logger.exception("Claude generation failed")
             return {"answer": f"Error: {e}", "confidence": 0.0}
-
-        prompt = f"{instruction}\n\n{query}" if instruction else query
-        try:
-            answer = self.generator.generate(prompt, contexts)
-            return {"answer": answer, "confidence": 0.6}
-        except Exception:
-            return {"answer": "", "confidence": 0.0}
-
 
     def answer(self, question: str, contexts: List[str]) -> Dict[str, Any]:
         return self.generate(question, contexts)

--- a/interface/cli.py
+++ b/interface/cli.py
@@ -5,7 +5,8 @@ Supports basic commands for status, health checks, and processing mode control.
 
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
+from enum import Enum
 
 # Ensure project root on path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
@@ -19,6 +20,13 @@ except Exception as e:
     raise
 
 
+class GraphMode(Enum):
+    """Retrieval modes for knowledge graph usage."""
+    TEXT = "text"
+    GRAPH = "graph"
+    HYBRID = "hybrid"
+
+
 class RAGCLI:
     """Simple interactive CLI for the RAG system."""
 
@@ -27,6 +35,8 @@ class RAGCLI:
         self.pipeline = HybridPipeline(self.config)
         self.health_checker = HealthChecker(self.config)
         self.current_mode = ProcessingMode.HYBRID_AUTO
+        self.retrieval_mode = GraphMode.TEXT
+        self.graph_built = False
         self.pipeline.initialize()
 
     def run(self) -> None:
@@ -47,6 +57,12 @@ class RAGCLI:
                     self.show_status()
                 elif user_input.lower() == "/health":
                     self.show_health()
+                elif user_input.lower() == "/buildkg":
+                    self.build_knowledge_graph()
+                elif user_input.lower() == "/graph":
+                    self.set_graph_mode("graph")
+                elif user_input.lower() == "/hybrid":
+                    self.set_graph_mode("hybrid")
                 elif user_input.lower().startswith("/mode"):
                     self.set_mode(user_input)
                 else:
@@ -60,6 +76,9 @@ class RAGCLI:
         print("  /status           Show pipeline status")
         print("  /health           Run health checks")
         print("  /mode <name>      Set processing mode")
+        print("  /buildkg          Build knowledge graph")
+        print("  /graph            Enable graph retrieval mode")
+        print("  /hybrid           Enable hybrid graph mode")
         print("  /help             Show this help message")
         print("  /quit             Exit the CLI")
 
@@ -69,6 +88,8 @@ class RAGCLI:
         for key, val in status.items():
             print(f"  {key}: {val}")
         print(f"Current mode: {self.current_mode.value}")
+        print(f"Retrieval mode: {self.retrieval_mode.value}")
+        print(f"KG built: {self.graph_built}")
 
     def show_health(self) -> None:
         results = self.health_checker.full_system_check()
@@ -94,9 +115,32 @@ class RAGCLI:
                 return
         print(f"Unknown mode: {mode_name}")
 
+    def set_graph_mode(self, mode: str) -> None:
+        mode = mode.lower()
+        if mode == "graph":
+            self.retrieval_mode = GraphMode.GRAPH
+            print("Graph mode enabled")
+        elif mode == "hybrid":
+            self.retrieval_mode = GraphMode.HYBRID
+            print("Hybrid graph mode enabled")
+        else:
+            print(f"Unknown graph mode: {mode}")
+
+    def build_knowledge_graph(self) -> None:
+        print("\n🔧 Building knowledge graph (stub)...")
+        self.graph_built = True
+        print("Knowledge graph ready")
+
+    def hybrid_retrieval(self, query: str) -> List[str]:
+        """Placeholder for knowledge graph retrieval."""
+        print("Retrieving contexts from knowledge graph (stub)")
+        return [f"KG context for: {query}"]
+
     def answer_query(self, query: str) -> None:
-        # Placeholder contexts for demonstration
-        contexts = ["This is a sample context for the query."]
+        if self.retrieval_mode in {GraphMode.GRAPH, GraphMode.HYBRID}:
+            contexts = self.hybrid_retrieval(query)
+        else:
+            contexts = ["This is a sample context for the query."]
         result = self.pipeline.process_query(query, contexts, self.current_mode)
         print(f"\nAnswer: {result.answer}")
         print(f"Confidence: {result.confidence:.3f}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,5 +65,27 @@ class TestCLI(unittest.TestCase):
         else:
             self.skipTest("set_mode not implemented")
 
+    def test_graph_mode_toggle(self):
+        if not self.cli_available:
+            self.skipTest("CLI not available")
+        if hasattr(self.cli, 'set_graph_mode'):
+            self.cli.set_graph_mode('graph')
+            self.assertTrue(hasattr(self.cli, 'retrieval_mode'))
+            self.cli.set_graph_mode('hybrid')
+            self.assertTrue(hasattr(self.cli, 'retrieval_mode'))
+        else:
+            self.skipTest("set_graph_mode not implemented")
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_build_kg(self, mock_stdout):
+        if not self.cli_available:
+            self.skipTest("CLI not available")
+        if hasattr(self.cli, 'build_knowledge_graph'):
+            self.cli.build_knowledge_graph()
+            output = mock_stdout.getvalue().lower()
+            self.assertIn('graph', output)
+        else:
+            self.skipTest("build_knowledge_graph not implemented")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `GraphMode` enum to track retrieval mode
- support `/buildkg`, `/graph`, and `/hybrid` commands
- print retrieval mode in status output
- implement stub knowledge graph retrieval
- simplify backend LLM classes
- test new CLI functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d18a4d44c83228809fe7cf4b11160