### PR TITLE
Add knowledge graph retrieval and fix LLM utils

### DIFF
--- a/backend/llm_generator.py
+++ b/backend/llm_generator.py
@@ -8,8 +8,7 @@ except Exception:  # pragma: no cover - anthropic optional
 
 
 class LLMGenerator:
-    """Simple wrapper around the Claude API."""
-
+    """Minimal wrapper around the Anthropic client."""
 
     def __init__(
         self,
@@ -18,12 +17,8 @@ class LLMGenerator:
         max_tokens: int = 512,
         temperature: float = 0.1,
     ) -> None:
-        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
-
-    def __init__(self, model: str = "claude-3-5-haiku-20241022"):
-        self.api_key = os.getenv("ANTHROPIC_API_KEY")
-
         self.model = model
+        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         self.max_tokens = max_tokens
         self.temperature = temperature
 
@@ -34,35 +29,24 @@ class LLMGenerator:
         instruction: Optional[str] = None,
         system_prompt: str = "",
     ) -> str:
+        """Call the Anthropic API and return the generated text."""
         if not self.api_key:
             raise ValueError("ANTHROPIC_API_KEY not set")
         if Anthropic is None:
             raise ImportError("anthropic package is required to use LLMGenerator")
+
         client = Anthropic(api_key=self.api_key)
         context = " ".join(context_sentences[:8])
-
         user_content = f"Context:\n{context}\n\nQuestion:\n{query}"
         if instruction:
             user_content = f"{instruction}\n\n{user_content}"
         messages = [{"role": "user", "content": user_content}]
-        try:  # pragma: no cover - runtime errors
-            response = client.messages.create(
-                model=self.model,
-                max_tokens=self.max_tokens,
-                temperature=self.temperature,
-                messages=messages,
-                system=system_prompt,
 
-        messages = [
-            {"role": "user", "content": f"Context: {context}\n\nQuestion: {query}"}
-        ]
-        try:  # pragma: no cover - runtime errors
-            response = client.messages.create(
-                model=self.model,
-                max_tokens=512,
-                messages=messages,
-
-            )
-            return "".join(block.text for block in response.content).strip()
-        except Exception as e:  # pragma: no cover - runtime errors
-            raise RuntimeError(f"Anthropic API call failed: {e}") from e
+        response = client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            messages=messages,
+            system=system_prompt,
+        )
+        return "".join(block.text for block in response.content).strip()

--- a/backend/qa_models.py
+++ b/backend/qa_models.py
@@ -1,23 +1,18 @@
-"""Claude-based QA models for the RAG system."""
-
 from typing import List, Dict, Any, Optional
-
 import logging
+
 from .llm_generator import LLMGenerator
 from .config import Config
-
 
 logger = logging.getLogger(__name__)
 
 
-
 class ClaudeQA:
-    """Simple wrapper that uses Claude for answer generation."""
+    """Wrapper that uses LLMGenerator to communicate with Claude."""
 
     def __init__(self, config: Optional[Config] = None) -> None:
         self.config = config or Config()
         model_name = getattr(self.config.claude, "model_name", "claude-3-5-haiku-20241022")
-
         self.generator = LLMGenerator(
             model=model_name,
             api_key=self.config.claude.api_key,
@@ -28,36 +23,24 @@ class ClaudeQA:
             "You are a helpful assistant that summarizes partnership and collaborator information from provided context."
         )
 
-        self.generator = LLMGenerator(model=model_name)
-
-
     def generate(
         self,
         query: str,
         contexts: List[str],
         instruction: Optional[str] = None,
     ) -> Dict[str, Any]:
-
-        prompt_instruction = instruction
+        """Generate an answer with Claude."""
         try:
             answer = self.generator.generate(
                 query,
                 contexts,
-                instruction=prompt_instruction,
+                instruction=instruction,
                 system_prompt=self.system_prompt,
             )
             return {"answer": answer, "confidence": 0.6}
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - runtime errors
             logger.exception("Claude generation failed")
             return {"answer": f"Error: {e}", "confidence": 0.0}
-
-        prompt = f"{instruction}\n\n{query}" if instruction else query
-        try:
-            answer = self.generator.generate(prompt, contexts)
-            return {"answer": answer, "confidence": 0.6}
-        except Exception:
-            return {"answer": "", "confidence": 0.0}
-
 
     def answer(self, question: str, contexts: List[str]) -> Dict[str, Any]:
         return self.generate(question, contexts)

--- a/processing/knowledge_graph.py
+++ b/processing/knowledge_graph.py
@@ -1,0 +1,127 @@
+"""Utility functions for working with a Neo4j knowledge graph and combining
+results with vector search.
+"""
+
+from typing import List, Dict, Any
+
+try:
+    from backend.config import Config
+except Exception:  # pragma: no cover - optional import for tests
+    Config = None  # type: ignore
+
+
+def _classify_query(query: str) -> str:
+    """Very small heuristic to decide retrieval strategy."""
+    q = query.lower()
+    graph_keywords = [
+        "relationship",
+        "connected",
+        "connect",
+        "who",
+        "partner",
+        "collaborator",
+    ]
+    return "graph" if any(k in q for k in graph_keywords) else "vector"
+
+
+def query_knowledge_graph(query: str, config: Config) -> List[Dict[str, Any]]:
+    """Query Neo4j using a simple Cypher traversal.
+
+    Parameters
+    ----------
+    query:
+        Free text describing the entity of interest.
+    config:
+        Application configuration with optional knowledge graph settings.
+
+    Returns
+    -------
+    List of dictionaries with node properties.
+    """
+    try:
+        from neo4j import GraphDatabase
+    except Exception:  # pragma: no cover - neo4j optional
+        raise ImportError("neo4j package required for knowledge graph queries")
+
+    kg_cfg = getattr(config, "knowledge_graph", None) or {}
+    uri = getattr(kg_cfg, "uri", "bolt://localhost:7687")
+    user = getattr(kg_cfg, "user", "neo4j")
+    password = getattr(kg_cfg, "password", "neo4j")
+
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    cypher = (
+        "MATCH (n)-[r*1..2]-(m) "
+        "WHERE toLower(n.name) CONTAINS toLower($q) "
+        "RETURN n, m LIMIT 20"
+    )
+    records: List[Dict[str, Any]] = []
+    with driver.session() as session:
+        result = session.run(cypher, q=query)
+        for rec in result:
+            item: Dict[str, Any] = {}
+            for key, val in rec.items():
+                if hasattr(val, "_properties"):
+                    props = dict(val._properties)
+                    props["id"] = getattr(val, "id", None)
+                    item[key] = props
+                else:
+                    item[key] = val
+            records.append(item)
+    return records
+
+
+def _vector_search(query: str, config: Config):
+    """Retrieve documents from Weaviate using Haystack components."""
+    try:
+        from haystack import Pipeline
+        from haystack.components.embedders import SentenceTransformersTextEmbedder
+        from haystack_integrations.document_stores.weaviate import (
+            WeaviateDocumentStore,
+        )
+        from haystack_integrations.components.retrievers.weaviate import (
+            WeaviateEmbeddingRetriever,
+        )
+    except Exception:  # pragma: no cover - optional dependencies
+        return []
+
+    document_store = WeaviateDocumentStore(url=config.weaviate.url)
+    embedder = SentenceTransformersTextEmbedder(model=config.embedding.model_name)
+    retriever = WeaviateEmbeddingRetriever(document_store=document_store)
+
+    pipeline = Pipeline()
+    pipeline.add_component("embedder", embedder)
+    pipeline.add_component("retriever", retriever)
+    pipeline.connect("embedder.embedding", "retriever.query_embedding")
+
+    result = pipeline.run(
+        {
+            "embedder": {"text": query},
+            "retriever": {"top_k": config.retrieval.default_top_k},
+        }
+    )
+    return result.get("retriever", {}).get("documents", [])
+
+
+def hybrid_retrieval(query: str, config: Config) -> List[str]:
+    """Combine graph traversal with vector search for retrieval."""
+    strategy = _classify_query(query)
+    contexts: List[str] = []
+
+    if strategy == "graph":
+        try:
+            graph_results = query_knowledge_graph(query, config)
+        except Exception:
+            graph_results = []
+        for item in graph_results:
+            n = item.get("n", {}).get("name", "")
+            m = item.get("m", {}).get("name", "")
+            if n and m:
+                contexts.append(f"{n} -> {m}")
+    
+    docs = _vector_search(query, config)
+    for doc in docs:
+        content = getattr(doc, "content", None)
+        if content:
+            contexts.append(str(content))
+
+    return contexts


### PR DESCRIPTION
## Summary
- implement `query_knowledge_graph` and `hybrid_retrieval`
- add basic query classification
- repair LLM utilities to satisfy unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d177e78148322ae8e235f71ac6480