### PR TITLE
Add Neo4j configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ model="sentence-transformers/all-MiniLM-L6-v2"  # Fast, good quality
 # model="sentence-transformers/all-mpnet-base-v2"  # Slower, higher quality
 ```
 
+### Neo4j Connection
+Specify Neo4j connection settings in `config.yaml`:
+```yaml
+neo4j:
+  uri: bolt://localhost:7687
+  user: neo4j
+  password: password
+```
+
 ## 🐳 Docker Configuration
 
 The system uses Docker Compose for Weaviate setup. Key services:

--- a/backend/config.py
+++ b/backend/config.py
@@ -93,6 +93,14 @@ class LoggingConfig:
     save_response_analytics: bool = False
 
 
+@dataclass
+class Neo4jConfig:
+    """Configuration for connecting to a Neo4j database."""
+    uri: str = "bolt://localhost:7687"
+    user: str = "neo4j"
+    password: str = "password"
+
+
 class Config:
     """Central configuration management."""
 
@@ -112,6 +120,7 @@ class Config:
         self.query_processing = QueryProcessingConfig()
         self.domain_detection = DomainDetectionConfig()
         self.logging = LoggingConfig()
+        self.neo4j = Neo4jConfig()
         self.section_priorities = {}
         self.semantic_metadata = {}
 
@@ -144,6 +153,7 @@ class Config:
                 "query_processing": self.query_processing,
                 "domain_detection": self.domain_detection,
                 "logging": self.logging,
+                "neo4j": self.neo4j,
             }
 
             for name, obj in config_mappings.items():
@@ -166,6 +176,12 @@ class Config:
             self.weaviate.url = os.getenv("WEAVIATE_URL")
         if os.getenv("ANTHROPIC_API_KEY"):
             self.claude.api_key = os.getenv("ANTHROPIC_API_KEY")
+        if os.getenv("NEO4J_URI"):
+            self.neo4j.uri = os.getenv("NEO4J_URI")
+        if os.getenv("NEO4J_USER"):
+            self.neo4j.user = os.getenv("NEO4J_USER")
+        if os.getenv("NEO4J_PASSWORD"):
+            self.neo4j.password = os.getenv("NEO4J_PASSWORD")
 
     def validate(self) -> List[str]:
         errors = []

--- a/config.yaml
+++ b/config.yaml
@@ -50,3 +50,8 @@ logging:
 hardware:
   use_gpu: false
   num_threads: 4
+
+neo4j:
+  uri: "bolt://localhost:7687"
+  user: "neo4j"
+  password: "password"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,9 +38,11 @@ class TestConfig(unittest.TestCase):
         self.assertTrue(hasattr(config, 'retrieval'))
         self.assertTrue(hasattr(config.retrieval, 'default_top_k'))
         self.assertTrue(hasattr(config, 'hardware'))
+        self.assertTrue(hasattr(config, 'neo4j'))
 
         self.assertIsInstance(config.retrieval.default_top_k, int)
         self.assertIsInstance(config.hardware.use_gpu, bool)
+        self.assertIsInstance(config.neo4j.uri, str)
 
     def test_validation(self):
         """Test configuration validation."""


### PR DESCRIPTION
## Summary
- allow configuring Neo4j connection
- document the new settings
- update default config
- test for new config field

## Testing
- `python tests/run_tests.py` *(fails: SyntaxError in qa_models / llm_generator)*

------
https://chatgpt.com/codex/tasks/task_e_688d158cece48322942cb0accf85b75e