### PR TITLE
Add basic Neo4j knowledge graph support

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -32,6 +32,14 @@ class ClaudeConfig:
 
 
 @dataclass
+class Neo4jConfig:
+    """Configuration for the Neo4j knowledge graph."""
+    uri: str = "bolt://localhost:7687"
+    user: str = "neo4j"
+    password: str = "neo4j"
+
+
+@dataclass
 class RetrievalConfig:
     default_top_k: int = 5
     partnership_top_k: int = 5
@@ -105,6 +113,7 @@ class Config:
         self.weaviate = WeaviateConfig()
         self.embedding = EmbeddingConfig()
         self.claude = ClaudeConfig()
+        self.neo4j = Neo4jConfig()
         self.retrieval = RetrievalConfig()
         self.prompting = PromptingConfig()
         self.hardware = HardwareConfig()
@@ -137,6 +146,7 @@ class Config:
                 "weaviate": self.weaviate,
                 "embedding": self.embedding,
                 "claude": self.claude,
+                "neo4j": self.neo4j,
                 "retrieval": self.retrieval,
                 "prompting": self.prompting,
                 "hardware": self.hardware,
@@ -166,6 +176,12 @@ class Config:
             self.weaviate.url = os.getenv("WEAVIATE_URL")
         if os.getenv("ANTHROPIC_API_KEY"):
             self.claude.api_key = os.getenv("ANTHROPIC_API_KEY")
+        if os.getenv("NEO4J_URI"):
+            self.neo4j.uri = os.getenv("NEO4J_URI")
+        if os.getenv("NEO4J_USER"):
+            self.neo4j.user = os.getenv("NEO4J_USER")
+        if os.getenv("NEO4J_PASSWORD"):
+            self.neo4j.password = os.getenv("NEO4J_PASSWORD")
 
     def validate(self) -> List[str]:
         errors = []
@@ -192,4 +208,5 @@ class Config:
             "claude_model": self.claude.model_name,
             "retrieval_default_top_k": self.retrieval.default_top_k,
             "use_gpu": self.hardware.use_gpu,
+            "neo4j_uri": self.neo4j.uri,
         }

--- a/backend/knowledge_graph.py
+++ b/backend/knowledge_graph.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Neo4j based knowledge graph utilities."""
+
+from typing import Iterable, Tuple
+
+from neo4j import GraphDatabase
+
+from .config import Config
+
+
+class KnowledgeGraph:
+    """Simple wrapper around a Neo4j database for document entities."""
+
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+        self.driver = GraphDatabase.driver(
+            self.config.neo4j.uri,
+            auth=(self.config.neo4j.user, self.config.neo4j.password),
+        )
+
+    def close(self) -> None:
+        self.driver.close()
+
+    def ingest_entities(self, triples: Iterable[Tuple[str, str, str, str, str]]) -> None:
+        """Ingest (source_type, source_name, rel, target_type, target_name)."""
+        with self.driver.session() as session:
+            for s_type, s_name, rel, t_type, t_name in triples:
+                query = (
+                    f"MERGE (a:{s_type} {{name:$s_name}}) "
+                    f"MERGE (b:{t_type} {{name:$t_name}}) "
+                    f"MERGE (a)-[:{rel}]->(b)"
+                )
+                session.run(query, s_name=s_name, t_name=t_name)
+
+    def query(self, cypher: str) -> list[dict]:
+        with self.driver.session() as session:
+            result = session.run(cypher)
+            return [record.data() for record in result]

--- a/backend/llm_generator.py
+++ b/backend/llm_generator.py
@@ -8,8 +8,7 @@ except Exception:  # pragma: no cover - anthropic optional
 
 
 class LLMGenerator:
-    """Simple wrapper around the Claude API."""
-
+    """Minimal wrapper around the Anthropic Claude API."""
 
     def __init__(
         self,
@@ -19,10 +18,6 @@ class LLMGenerator:
         temperature: float = 0.1,
     ) -> None:
         self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
-
-    def __init__(self, model: str = "claude-3-5-haiku-20241022"):
-        self.api_key = os.getenv("ANTHROPIC_API_KEY")
-
         self.model = model
         self.max_tokens = max_tokens
         self.temperature = temperature
@@ -38,6 +33,7 @@ class LLMGenerator:
             raise ValueError("ANTHROPIC_API_KEY not set")
         if Anthropic is None:
             raise ImportError("anthropic package is required to use LLMGenerator")
+
         client = Anthropic(api_key=self.api_key)
         context = " ".join(context_sentences[:8])
 
@@ -45,6 +41,7 @@ class LLMGenerator:
         if instruction:
             user_content = f"{instruction}\n\n{user_content}"
         messages = [{"role": "user", "content": user_content}]
+
         try:  # pragma: no cover - runtime errors
             response = client.messages.create(
                 model=self.model,
@@ -52,16 +49,6 @@ class LLMGenerator:
                 temperature=self.temperature,
                 messages=messages,
                 system=system_prompt,
-
-        messages = [
-            {"role": "user", "content": f"Context: {context}\n\nQuestion: {query}"}
-        ]
-        try:  # pragma: no cover - runtime errors
-            response = client.messages.create(
-                model=self.model,
-                max_tokens=512,
-                messages=messages,
-
             )
             return "".join(block.text for block in response.content).strip()
         except Exception as e:  # pragma: no cover - runtime errors

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,11 @@ weaviate:
 embedding:
   model_name: "sentence-transformers/all-MiniLM-L6-v2"
 
+neo4j:
+  uri: "bolt://localhost:7687"
+  user: "neo4j"
+  password: "neo4j"
+
 claude:
   api_key: ""
   model_name: "claude-3-5-haiku-20241022"

--- a/neo4j_loader.py
+++ b/neo4j_loader.py
@@ -1,0 +1,49 @@
+"""Utility to build a knowledge graph in Neo4j from documents."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from backend.config import Config
+from backend.knowledge_graph import KnowledgeGraph
+from domain_loader import load_text_file, load_pdf_file, load_docx_file
+
+
+def extract_simple_entities(text: str) -> Iterable[str]:
+    """Very naive entity extractor based on capitalised words."""
+    pattern = re.compile(r"\b([A-Z][A-Za-z0-9_]+(?:\s+[A-Z][A-Za-z0-9_]+)*)")
+    for match in pattern.finditer(text):
+        yield match.group(1)
+
+
+def load_documents(folder: Path) -> Iterable[Tuple[str, str]]:
+    """Yield (filename, content) for supported documents."""
+    loaders = {
+        ".txt": load_text_file,
+        ".md": load_text_file,
+        ".pdf": load_pdf_file,
+        ".docx": load_docx_file,
+    }
+    for path in folder.rglob("*"):
+        if path.suffix.lower() in loaders and path.is_file():
+            yield path.name, loaders[path.suffix.lower()](str(path))
+
+
+def build_graph(config: Config | None = None) -> None:
+    cfg = config or Config()
+    kg = KnowledgeGraph(cfg)
+    folder = Path(cfg.documents_folder)
+    triples = []
+    for name, content in load_documents(folder):
+        doc_node = ("Document", name, "CONTAINS", "Sentence", name)
+        # each entity becomes Concept node
+        for entity in extract_simple_entities(content):
+            triples.append(("Document", name, "MENTIONS", "Concept", entity))
+    if triples:
+        kg.ingest_entities(triples)
+    kg.close()
+
+
+if __name__ == "__main__":
+    build_graph()

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,9 @@ pytest>=7.0.0
 # Dependencies that might be needed
 tqdm>=4.64.0
 
+# Neo4j driver for knowledge graph integration
+neo4j>=5.16.0
+
 # Optional: Fix protobuf warnings (uncomment if needed)
 # protobuf>=5.29.0,<6.0
 # LLM client

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from backend.config import Config
+from backend.knowledge_graph import KnowledgeGraph
+
+
+class TestKnowledgeGraph(unittest.TestCase):
+    def test_ingest_entities_calls_neo4j(self):
+        mock_driver = MagicMock()
+        mock_session = MagicMock()
+        mock_driver.session.return_value.__enter__.return_value = mock_session
+        with patch('backend.knowledge_graph.GraphDatabase.driver', return_value=mock_driver):
+            kg = KnowledgeGraph(Config())
+            triples = [
+                ('Concept', 'AI', 'DEFINED_AS', 'Definition', 'Artificial Intelligence'),
+                ('Theory', 'ML', 'DEVELOPED_BY', 'Person', 'Turing'),
+            ]
+            kg.ingest_entities(triples)
+            self.assertEqual(mock_session.run.call_count, len(triples))
+            kg.close()
+            mock_driver.close.assert_called_once()
+
+    def test_query_returns_data(self):
+        mock_driver = MagicMock()
+        mock_session = MagicMock()
+        mock_record = MagicMock()
+        mock_record.data.return_value = {'n': 1}
+        mock_session.run.return_value = [mock_record]
+        mock_driver.session.return_value.__enter__.return_value = mock_session
+        with patch('backend.knowledge_graph.GraphDatabase.driver', return_value=mock_driver):
+            kg = KnowledgeGraph(Config())
+            res = kg.query('MATCH (n) RETURN n')
+            self.assertEqual(res, [{'n': 1}])
+


### PR DESCRIPTION
## Summary
- add Neo4j driver dependency
- extend configuration with Neo4j settings and env overrides
- implement `KnowledgeGraph` wrapper for Neo4j operations
- provide `neo4j_loader.py` to build a simple graph from documents
- fix `LLMGenerator` implementation
- add tests for the knowledge graph module

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688d130c1dac8322a316178cd09dc17d