### PR TITLE
Integrate Neo4j knowledge graph into RAG pipeline

### DIFF
--- a/backend/knowledge_graph.py
+++ b/backend/knowledge_graph.py
@@ -1,4 +1,6 @@
 
+from __future__ import annotations
+
 from typing import List, Tuple
 from neo4j import Driver
 
@@ -38,8 +40,6 @@ def hybrid_retrieval(query: str, vector_results: List[str], driver: Driver, top_
         if len(combined) >= top_k:
             break
     return combined
-
-from __future__ import annotations
 
 """Neo4j based knowledge graph utilities."""
 


### PR DESCRIPTION
## Summary
- add Neo4jGraphBuilder and HybridQueryRouter for entity extraction and graph traversal
- wire Neo4j-driven retrieval into a new RAGPipeline and main flow
- fix knowledge_graph future import placement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0f9ef5788322a4d25617a30dcbed