### PR TITLE
Fix JSON template formatting for extraction prompt

### DIFF
--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -512,14 +512,14 @@ RELATIONSHIPS TO EXTRACT (capture semantic connections):
 - Location (LOCATED_IN, BASED_IN, OPERATES_IN)
 
 Return comprehensive JSON format:
-{
+{{
     "entities": [
-        {"name": "Entity Name", "type": "Organization|Project|Technology|Person|Concept|Location|Product", "properties": {"description": "brief context"}}
+        {{"name": "Entity Name", "type": "Organization|Project|Technology|Person|Concept|Location|Product", "properties": {{"description": "brief context"}}}}
     ],
     "relationships": [
-        {"source": "Entity1", "target": "Entity2", "relationship": "RELATIONSHIP_TYPE", "properties": {"context": "relationship description"}}
+        {{"source": "Entity1", "target": "Entity2", "relationship": "RELATIONSHIP_TYPE", "properties": {{"context": "relationship description"}}}}
     ]
-}
+}}
 
 Be thorough - extract every meaningful entity and relationship mentioned.
 


### PR DESCRIPTION
## Summary
- escape all curly braces in the entity extraction JSON template so Python `.format` doesn't misinterpret them

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e93a43990832293fefdec8a562a32