### PR TITLE
Fix Claude API parameter usage in extractor

### DIFF
--- a/tests/test_comprehensive_extractor.py
+++ b/tests/test_comprehensive_extractor.py
@@ -7,7 +7,12 @@ from processing.comprehensive_extractor import ComprehensiveExtractor
 class DummyClaude:
     """Simple stub that returns predetermined responses."""
 
-    def generate(self, query: str, system_prompt: str | None = None):
+    def generate(
+        self,
+        query: str,
+        contexts: list[str],
+        instruction: str | None = None,
+    ):
         if "Analyze this document structure" in query:
             return {"answer": '{}'}
         if "CRITICAL: Extract ALL organizational entities" in query:


### PR DESCRIPTION
## Summary
- update ComprehensiveExtractor to call ClaudeQA with `instruction` and `contexts` instead of `system_prompt`
- adjust tests to new ClaudeQA.generate signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f65c23004832291a2503f4c7555ce