### PR TITLE
Use config-based Neo4j credentials

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -35,8 +35,8 @@ class ClaudeConfig:
 class Neo4jConfig:
     """Configuration for the Neo4j knowledge graph."""
     uri: str = "bolt://localhost:7687"
-    user: str = "neo4j"
-    password: str = "neo4j"
+    user: str = ""
+    password: str = ""
 
 
 @dataclass
@@ -101,14 +101,6 @@ class LoggingConfig:
     save_response_analytics: bool = False
 
 
-@dataclass
-class Neo4jConfig:
-    """Configuration for connecting to a Neo4j database."""
-    uri: str = "bolt://localhost:7687"
-    user: str = "neo4j"
-    password: str = "password"
-
-
 class Config:
     """Central configuration management."""
 
@@ -129,7 +121,6 @@ class Config:
         self.query_processing = QueryProcessingConfig()
         self.domain_detection = DomainDetectionConfig()
         self.logging = LoggingConfig()
-        self.neo4j = Neo4jConfig()
         self.section_priorities = {}
         self.semantic_metadata = {}
 
@@ -163,7 +154,6 @@ class Config:
                 "query_processing": self.query_processing,
                 "domain_detection": self.domain_detection,
                 "logging": self.logging,
-                "neo4j": self.neo4j,
             }
 
             for name, obj in config_mappings.items():

--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -433,8 +433,12 @@ def create_natural_answer(sentences, query):
 
 
 class Neo4jGraphBuilder:
-    def __init__(self, uri="bolt://localhost:7687", user="neo4j", password="password"):
-        self.driver = GraphDatabase.driver(uri, auth=(user, password))
+    def __init__(self, config: Config | None = None):
+        self.config = config or CONFIG
+        self.driver = GraphDatabase.driver(
+            self.config.neo4j.uri,
+            auth=(self.config.neo4j.user, self.config.neo4j.password),
+        )
         self.claude_extractor = LLMGenerator(model="claude-3-5-haiku-20241022")
 
     def extract_json_from_claude_response(self, response_text):
@@ -831,7 +835,7 @@ class RAGPipeline:
         self.retriever = retriever
         self.text_embedder = text_embedder
         # Add Neo4j integration
-        self.graph_builder = Neo4jGraphBuilder()
+        self.graph_builder = Neo4jGraphBuilder(CONFIG)
         self.hybrid_router = HybridQueryRouter(self.graph_builder, self.retriever, self.text_embedder)
 
     def get_document_fingerprint(self):


### PR DESCRIPTION
## Summary
- expose Neo4j URI, user and password via Config and load from `config.yaml`
- connect to Neo4j using config credentials in knowledge graph queries and builder
- wire Neo4jGraphBuilder and RAG pipeline to use configuration instead of hardcoded auth

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f9cd26324832282fd6c583ad8734e