### PR TITLE
Fix natural-language graph queries

### DIFF
--- a/processing/knowledge_graph.py
+++ b/processing/knowledge_graph.py
@@ -103,11 +103,7 @@ def query_knowledge_graph(query: str, config: Config) -> List[Dict[str, Any]]:
     records: List[Dict[str, Any]] = []
     try:
         with driver.session() as session:
-
             result = session.run(cypher, q=entity)
-
-            result = session.run(cypher, q=query)
-
             for rec in result:
                 item: Dict[str, Any] = {}
                 for key, val in rec.items():

--- a/tests/test_processing_graph.py
+++ b/tests/test_processing_graph.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock, patch
+
+from backend.config import Config
+from processing.knowledge_graph import query_knowledge_graph
+
+
+def test_query_knowledge_graph_uses_extracted_entity():
+    config = Config()
+    mock_session = Mock()
+    mock_session.run.return_value = []
+    mock_context = Mock(__enter__=Mock(return_value=mock_session), __exit__=Mock(return_value=None))
+    mock_driver = Mock()
+    mock_driver.session.return_value = mock_context
+    with patch('neo4j.GraphDatabase.driver', return_value=mock_driver):
+        query_knowledge_graph('what is Scania role', config)
+    cypher = (
+        "MATCH (n)-[r*1..2]-(m) "
+        "WHERE toLower(n.name) CONTAINS toLower($q) "
+        "RETURN n, m LIMIT 20"
+    )
+    mock_session.run.assert_called_once_with(cypher, q='Scania')


### PR DESCRIPTION
## Summary
- Correct knowledge graph query to use the extracted entity name rather than the full question
- Add regression test ensuring natural language queries pass the extracted entity to Neo4j

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc136b3c08322a7f0c0b4f5828213