### PR TITLE
Improve entity extraction for more question formats

### DIFF
--- a/processing/knowledge_graph.py
+++ b/processing/knowledge_graph.py
@@ -37,12 +37,23 @@ def _extract_entity_name(query: str) -> str:
         r"who are(?: the)? (.+?)'s partners",
         r"who are(?: the)? (.+?) partners",
         r"who does (.+?) partner with",
+        r"what is(?: an?| the)? (.+)",
     ]
     for pattern in patterns:
         match = re.search(pattern, query, flags=re.IGNORECASE)
         if match:
             entity = match.group(1).strip()
             entity = re.sub(r"[?.,]$", "", entity).strip()
+            return entity
+
+    # If a question references an entity via a trailing preposition like
+    # "in", "for" or "to", capture the part after the final connector.
+    if re.search(r"\b(who|what|where|when|why|how)\b", query, flags=re.IGNORECASE):
+        tail = re.search(
+            r"(?:in|for|to|of|on|at)\s+([^?.,]+)\s*$", query, flags=re.IGNORECASE
+        )
+        if tail:
+            entity = tail.group(1).strip()
             return entity
 
     question_words = {"who", "what", "where", "when", "why", "how"}

--- a/tests/test_query_parsing.py
+++ b/tests/test_query_parsing.py
@@ -16,6 +16,18 @@ def test_extract_entity_name_direct():
     assert _extract_entity_name("University of Skövde") == "University of Skövde"
 
 
+def test_extract_entity_name_simple_what_is():
+    assert _extract_entity_name("what is evidence theory") == "evidence theory"
+
+
+def test_extract_entity_name_numbers():
+    assert _extract_entity_name("what is concept 1") == "concept 1"
+
+
+def test_extract_entity_name_preposition():
+    assert _extract_entity_name("how is applied in I2Connect") == "I2Connect"
+
+
 def test_classify_role_as_graph():
     assert _classify_query("what is Smart Eye role?") == "graph"
 


### PR DESCRIPTION
## Summary
- broaden `_extract_entity_name` to handle general 'what is' questions and entities after trailing prepositions
- add tests for evidence theory, numeric concepts, and preposition-based queries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fc967dfb08322b6c2387a6ac0a269