### PR TITLE
Extend query parsing for additional entity patterns

### DIFF
--- a/processing/knowledge_graph.py
+++ b/processing/knowledge_graph.py
@@ -38,12 +38,17 @@ def _extract_entity_name(query: str) -> str:
         r"who are(?: the)? (.+?) partners",
         r"who does (.+?) partner with",
         r"what is(?: an?| the)? (.+)",
+        r"who is(?: the)? (.+)",
+        r"where is(?: the)? (.+)",
+        r"how does(?: the)? (.+?) relate to (.+)",
     ]
     for pattern in patterns:
         match = re.search(pattern, query, flags=re.IGNORECASE)
         if match:
             entity = match.group(1).strip()
             entity = re.sub(r"[?.,]$", "", entity).strip()
+            if re.search(r"\b(?:in|for|to|of|on|at|with)\b$", entity, flags=re.IGNORECASE):
+                continue
             return entity
 
     # If a question references an entity via a trailing preposition like

--- a/tests/test_query_parsing.py
+++ b/tests/test_query_parsing.py
@@ -28,6 +28,20 @@ def test_extract_entity_name_preposition():
     assert _extract_entity_name("how is applied in I2Connect") == "I2Connect"
 
 
+def test_extract_entity_name_who_is():
+    assert _extract_entity_name("who is Alan Turing?") == "Alan Turing"
+
+
+def test_extract_entity_name_where_is():
+    text = "where is the University of Skövde?"
+    assert _extract_entity_name(text) == "University of Skövde"
+
+
+def test_extract_entity_name_how_does_relate():
+    text = "how does the University of Skövde relate to Smart Eye?"
+    assert _extract_entity_name(text) == "University of Skövde"
+
+
 def test_classify_role_as_graph():
     assert _classify_query("what is Smart Eye role?") == "graph"
 


### PR DESCRIPTION
## Summary
- expand regex patterns in `_extract_entity_name` to handle "who is", "where is", and "how does … relate to …" queries
- guard against trailing prepositions so multi-word entities remain intact
- add tests for new entity extraction patterns

## Testing
- `pytest tests/test_query_parsing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689078a4062c8322a18207e3e057539e