### PR TITLE
fix: correct OOD config indentation

### DIFF
--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -1283,18 +1283,11 @@ def main():
     # Update OOD centroid and adjust threshold using sample queries
     pipeline.ood_agent.domain_centroid = pipeline.ood_agent._compute_domain_centroid()
 
-    if CONFIG.ood.enabled:
-
-
     if getattr(CONFIG, "ood", SimpleNamespace(enabled=False)).enabled:
-
-    if CONFIG.get("ood", {}).get("enabled", True):
-
-
         sample_queries = [
             "What is Project Orion?",
             "Explain Scania's role in ADAS development",
-            "How does Viscando's technology integrate with Smart Eye?"
+            "How does Viscando's technology integrate with Smart Eye?",
         ]
         pipeline.ood_agent.auto_adjust_threshold(sample_queries)
 


### PR DESCRIPTION
## Summary
- fix indentation around the OOD configuration check in the transformer pipeline
- adjust out-of-domain sample query handling to run only when OOD is enabled

## Testing
- `python -m py_compile weaviate_rag_pipeline_transformers.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890cfa332f883228f7b37d9a51306f8