### PR TITLE
fix: replace union operator for py39

### DIFF
--- a/backend/knowledge_graph.py
+++ b/backend/knowledge_graph.py
@@ -1,7 +1,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, List, Tuple
+from typing import Any, Callable, Iterable, List, Tuple, Optional
 
 try:  # pragma: no cover - optional dependency
     from neo4j import Driver, GraphDatabase
@@ -85,7 +85,7 @@ from .config import Config
 class KnowledgeGraph:
     """Simple wrapper around a Neo4j database for document entities."""
 
-    def __init__(self, config: Config | None = None) -> None:
+    def __init__(self, config: Optional[Config] = None) -> None:
         self.config = config or Config()
         self.driver = GraphDatabase.driver(
             self.config.neo4j.uri,

--- a/neo4j_loader.py
+++ b/neo4j_loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, Optional
 
 from backend.config import Config
 from backend.knowledge_graph import KnowledgeGraph
@@ -30,7 +30,7 @@ def load_documents(folder: Path) -> Iterable[Tuple[str, str]]:
             yield path.name, loaders[path.suffix.lower()](str(path))
 
 
-def build_graph(config: Config | None = None) -> None:
+def build_graph(config: Optional[Config] = None) -> None:
     cfg = config or Config()
     kg = KnowledgeGraph(cfg)
     folder = Path(cfg.documents_folder)

--- a/tests/test_comprehensive_extractor.py
+++ b/tests/test_comprehensive_extractor.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from typing import Optional
 
 from processing.comprehensive_extractor import ComprehensiveExtractor
 
@@ -11,7 +12,7 @@ class DummyClaude:
         self,
         query: str,
         contexts: list[str],
-        instruction: str | None = None,
+        instruction: Optional[str] = None,
     ):
         if "Analyze this document structure" in query:
             return {"answer": '{}'}

--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -449,7 +449,7 @@ def create_natural_answer(sentences, query):
 
 
 class Neo4jGraphBuilder:
-    def __init__(self, config: Config | None = None):
+    def __init__(self, config: Optional[Config] = None):
         self.config = config or CONFIG
         self.driver = GraphDatabase.driver(
             self.config.neo4j.uri,


### PR DESCRIPTION
## Summary
- avoid Python 3.9 TypeError by replacing `Config | None` with `Optional[Config]` across modules
- update unit test stub to use `Optional[str]` for Python 3.9 compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890dfb693dc832288fe9edc3557737f