### PR TITLE
fix: use Config attribute access for threshold

### DIFF
--- a/ood_verification.py
+++ b/ood_verification.py
@@ -204,7 +204,7 @@ class OODVerificationAgent:
         setattr(self.ood_config, "similarity_threshold", new_threshold)
         print(f"🔧 Auto-adjusted similarity threshold to {new_threshold:.2f}")
 
-        self.config["ood"]["similarity_threshold"] = new_threshold
+        self.config.ood.similarity_threshold = new_threshold
         print(
             f"\ud83d\udd27 Auto-adjusted similarity threshold to {new_threshold:.2f}"
         )


### PR DESCRIPTION
## Summary
- fix OOD auto-threshold update to use Config attributes instead of dict indexing

## Testing
- `pytest tests/test_ood_verification.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890e62b181c83229c4ed14312aaf8af