### PR TITLE
fix unicode error in ood verification

### DIFF
--- a/ood_verification.py
+++ b/ood_verification.py
@@ -199,14 +199,6 @@ class OODVerificationAgent:
 
         setattr(self.ood_config, "similarity_threshold", new_threshold)
         print(f"🔧 Auto-adjusted similarity threshold to {new_threshold:.2f}")
-
-
-        setattr(self.ood_config, "similarity_threshold", new_threshold)
-        print(f"🔧 Auto-adjusted similarity threshold to {new_threshold:.2f}")
-
         self.config.ood.similarity_threshold = new_threshold
-        print(
-            f"\ud83d\udd27 Auto-adjusted similarity threshold to {new_threshold:.2f}"
-        )
 
 


### PR DESCRIPTION
## Summary
- remove surrogate pair print that caused UnicodeEncodeError during threshold adjustment
- streamline threshold update to use valid UTF-8

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ea62194083229d21b4c4df69f8ed