### PR TITLE
feat: add domain keyword fallback for OOD

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -105,8 +105,10 @@ class LoggingConfig:
 class OODConfig:
     """Out-of-domain verification settings."""
     enabled: bool = False
-    similarity_threshold: float = 0.65
+    similarity_threshold: float = 0.25
+    similarity_check_enabled: bool = True
     min_neo4j_relations: int = 1
+    domain_keywords: List[str] = field(default_factory=list)
 
 
 class Config:

--- a/config.yaml
+++ b/config.yaml
@@ -58,5 +58,8 @@ hardware:
 
 ood:
   enabled: true
-  similarity_threshold: 0.35
+  similarity_threshold: 0.25
+  similarity_check_enabled: true
+  domain_keywords:
+    - evidence theory
   min_neo4j_relations: 1


### PR DESCRIPTION
## Summary
- lower OOD similarity threshold to 0.25
- add debug logger setup and keyword whitelist fallback
- allow skipping similarity check for easier development

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891046ec47c83229228e6e44bf2a191