### PR TITLE
Relax response verification for high confidence

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,4 +102,6 @@ ood_detection:
     enable_fact_checking: true
     enable_consistency_validation: true
     enable_citation_verification: true
-    hallucination_detection_threshold: 0.2
+    hallucination_detection_threshold: 0.3
+    high_confidence_threshold: 0.9
+    relaxed_hallucination_threshold: 0.5


### PR DESCRIPTION
## Summary
- relax hallucination detection threshold and introduce high-confidence override to avoid unnecessary refusals
- propagate generation confidence into response verification
- update default configuration with new tuning knobs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891c671b1f48322b9b1f55251a6ffc5