### PR TITLE
Use semantic similarity for response verification

### DIFF
--- a/tests/test_multi_layer_ood.py
+++ b/tests/test_multi_layer_ood.py
@@ -27,6 +27,7 @@ class TestMultiLayerOOD(unittest.TestCase):
             enable_consistency_validation=True,
             enable_citation_verification=True,
             hallucination_detection_threshold=0.3,
+            source_match_threshold=0.5,
         )
         cfg = OODDetectionConfig(
             similarity_threshold=0.1,
@@ -83,6 +84,18 @@ class TestMultiLayerOOD(unittest.TestCase):
             sources=["Evidence theory deals with uncertainty"],
         )
         self.assertFalse(res.get("response_verified"))
+
+    def test_response_verification_paraphrase(self):
+        res = self.detector.process(
+            query="Explain evidence theory",
+            similarity=0.9,
+            graph_connectivity=0.9,
+            retrieved_relevances=[0.9, 0.9],
+            token_probs=[0.9, 0.9],
+            answer="Evidence theory deals with uncertain information",
+            sources=["Evidence theory deals with uncertainty"],
+        )
+        self.assertTrue(res.get("response_verified"))
 
     def test_complex_query_analysis(self):
         analysis = self.detector.query_analyzer.analyze(


### PR DESCRIPTION
## Summary
- make response verification semantic by tokenizing text and matching with Jaccard similarity
- expose configurable `source_match_threshold` for tuning verification
- test paraphrased responses to ensure semantic matches are accepted

## Testing
- `pytest tests/test_multi_layer_ood.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891ca53bda88322ac9d4b38b099070f