### PR TITLE
Condense verification sources

### DIFF
--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -1264,7 +1264,11 @@ class RAGPipeline:
             }
 
         answer = self.hybrid_router.synthesize_answer(query, hybrid_results)
-        sources = [doc.content for doc in hybrid_results["vector_results"]]
+        sources = []
+        for doc in hybrid_results["vector_results"]:
+            sentences = self.text_processor.extract_quality_sentences(doc.content)
+            snippet = sentences[0] if sentences else doc.content[:200]
+            sources.append(snippet)
         verified, _ = self.ood_detector.verifier.verify(answer, sources, query)
         if not verified:
             answer = "I'm not fully confident about this answer."


### PR DESCRIPTION
## Summary
- Extract a representative sentence from each retrieved document before response verification
- Add unit tests ensuring snippet-based verification in the RAG pipeline

## Testing
- `pytest tests/test_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6891da5565748322875c184d77e62ef6