### PR TITLE
Improve response verification tolerance

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,3 +105,4 @@ ood_detection:
     hallucination_detection_threshold: 0.3
     high_confidence_threshold: 0.9
     relaxed_hallucination_threshold: 0.5
+    source_match_threshold: 0.5

--- a/tests/test_multi_layer_ood.py
+++ b/tests/test_multi_layer_ood.py
@@ -97,6 +97,18 @@ class TestMultiLayerOOD(unittest.TestCase):
         )
         self.assertTrue(res.get("response_verified"))
 
+    def test_short_answer_verification(self):
+        res = self.detector.process(
+            query="Explain evidence theory",
+            similarity=0.9,
+            graph_connectivity=0.9,
+            retrieved_relevances=[0.9, 0.9],
+            token_probs=[0.9, 0.9],
+            answer="Dempster Shafer",
+            sources=["Evidence Theory also called Dempster Shafer Theory"],
+        )
+        self.assertTrue(res.get("response_verified"))
+
     def test_complex_query_analysis(self):
         analysis = self.detector.query_analyzer.analyze(
             "How does evidence theory compare to probability and statistics in safety systems?"


### PR DESCRIPTION
## Summary
- make response verification use token overlap ratio instead of Jaccard score
- lower default source match threshold and expose in config
- test verification with short answers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891fb4c68708322ad717b0fc6ca1fd6