### PR TITLE
Improve response verification for RAG pipeline

### DIFF
--- a/tests/test_multi_layer_ood.py
+++ b/tests/test_multi_layer_ood.py
@@ -97,6 +97,21 @@ class TestMultiLayerOOD(unittest.TestCase):
         )
         self.assertTrue(res.get("response_verified"))
 
+    def test_response_verification_single_match_many_sources(self):
+        res = self.detector.process(
+            query="Explain evidence theory",
+            similarity=0.9,
+            graph_connectivity=0.9,
+            retrieved_relevances=[0.9, 0.9],
+            token_probs=[0.9, 0.9],
+            answer="Evidence theory deals with uncertain information",
+            sources=[
+                "Completely unrelated passage about other topics",
+                "Evidence theory deals with uncertainty",
+            ],
+        )
+        self.assertTrue(res.get("response_verified"))
+
     def test_short_answer_verification(self):
         res = self.detector.process(
             query="Explain evidence theory",


### PR DESCRIPTION
## Summary
- refine response verification to consider best overlap with sources instead of averaging across all retrieved snippets
- gate final responses on overlap quality to avoid unnecessary refusals
- test that a single matching source among many still verifies the answer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891fdf53cc083229797c5b3d48e050e