### PR TITLE
Optimize chunking to reduce API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Type `quit` to exit.
 ### Chunk Size and Overlap
 Modify chunking parameters in `weaviate_rag_pipeline_transformers.py`:
 ```python
-chunks = chunk_text(content, chunk_size=500, overlap=100)
+chunks = chunk_text(content, chunk_size=2000, overlap=200)
 ```
 
 ### Retrieval Settings

--- a/backend/config.py
+++ b/backend/config.py
@@ -116,8 +116,8 @@ class Config:
 
     def __init__(self, config_path: str = "config.yaml"):
         self.documents_folder = "documents"
-        self.chunk_size = 500
-        self.chunk_overlap = 100
+        self.chunk_size = 2000
+        self.chunk_overlap = 200
         self.development = True
 
         self.weaviate = WeaviateConfig()

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,8 @@
 # RAG System Configuration for Claude Haiku
 
 documents_folder: "documents"
-chunk_size: 500
-chunk_overlap: 100
+chunk_size: 2000
+chunk_overlap: 200
 development: true
 
 weaviate:

--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -103,25 +103,56 @@ def load_docx_file(file_path: str) -> str:
         print(f"❌ Error reading DOCX {file_path}: {e}")
         return ""
 
-def chunk_text(text: str, chunk_size: int = 500, overlap: int = 100) -> List[str]:
-    sentences = re.split(r'(?<=[.!?])\s+', text)
-    chunks = []
-    current_chunk = []
-    current_length = 0
-    
-    for sentence in sentences:
-        sent_length = len(sentence)
-        if current_length + sent_length > chunk_size and current_chunk:
-            chunks.append(" ".join(current_chunk))
-            overlap_count = max(1, int(len(current_chunk) * 0.3))
-            current_chunk = current_chunk[-overlap_count:]
-            current_length = sum(len(s) for s in current_chunk)
-        
-        current_chunk.append(sentence)
-        current_length += sent_length
-    
+def chunk_text(text: str, chunk_size: int = 2000, overlap: int = 200) -> List[str]:
+    """Split text into large chunks while preserving bullet lists."""
+
+    bullet_re = re.compile(r"^\s*(?:[-*]|\d+\.)\s+")
+    lines = text.splitlines()
+    segments: List[str] = []
+    buffer: List[str] = []
+    in_bullet = False
+
+    for line in lines:
+        if bullet_re.match(line):
+            if not in_bullet and buffer:
+                segments.append(" ".join(buffer).strip())
+                buffer = []
+            in_bullet = True
+            buffer.append(line.strip())
+        else:
+            if in_bullet and buffer:
+                segments.append("\n".join(buffer).strip())
+                buffer = []
+            in_bullet = False
+            buffer.append(line.strip())
+
+    if buffer:
+        if in_bullet:
+            segments.append("\n".join(buffer).strip())
+        else:
+            segments.append(" ".join(buffer).strip())
+
+    chunks: List[str] = []
+    current_chunk: List[str] = []
+    current_tokens = 0
+
+    for seg in segments:
+        seg_tokens = len(seg.split())
+        if current_tokens + seg_tokens > chunk_size and current_chunk:
+            chunks.append("\n".join(current_chunk))
+            if overlap > 0:
+                tokens = "\n".join(current_chunk).split()
+                overlap_tokens = tokens[-overlap:]
+                current_chunk = [" ".join(overlap_tokens)]
+                current_tokens = len(overlap_tokens)
+            else:
+                current_chunk = []
+                current_tokens = 0
+        current_chunk.append(seg)
+        current_tokens += seg_tokens
+
     if current_chunk:
-        chunks.append(" ".join(current_chunk))
+        chunks.append("\n".join(current_chunk))
 
     return chunks
 
@@ -201,7 +232,11 @@ def load_documents_from_folder(folder_path: str) -> List[Document]:
                 sections = split_into_sections(content, patterns)
                 chunk_pairs = []
                 for section_name, section_text in sections:
-                    chs = chunk_text(section_text, chunk_size=500, overlap=100)
+                    chs = chunk_text(
+                        section_text,
+                        chunk_size=CONFIG.chunk_size,
+                        overlap=CONFIG.chunk_overlap,
+                    )
                     for ch in chs:
                         chunk_pairs.append((section_name, ch))
 


### PR DESCRIPTION
## Summary
- increase default chunk size and overlap to 2000/200 tokens
- add bullet-aware chunking to batch small list items into larger segments
- wire up configuration-driven chunking throughout pipeline and docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689469604b388322864c2a3ec739df1b