### PR TITLE
feat: add research-backed response verification

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -99,10 +99,9 @@ ood_detection:
     confidence_explanation: true
 
   response_verification:
-    enable_fact_checking: true
-    enable_consistency_validation: true
-    enable_citation_verification: true
-    hallucination_detection_threshold: 0.3
-    high_confidence_threshold: 0.9
-    relaxed_hallucination_threshold: 0.5
-    source_match_threshold: 0.5
+    relevance_threshold: 0.5
+    min_relevant_passages: 1
+    lexical_similarity_threshold: 0.5
+    max_entropy_threshold: 2.0
+    mean_entropy_threshold: 1.5
+    sar_threshold: 0.0


### PR DESCRIPTION
## Summary
- add configurable relevance and uncertainty thresholds for response verification
- score and filter context using RankRAG-style relevance assessor
- compute lexical similarity, entropy, and SAR metrics to derive confidence and explicit abstention reasons

## Testing
- `pytest tests/test_multi_layer_ood.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894902b14108322b41b464a581b1685