### PR TITLE
Add debug logging for context relevance and tests

### DIFF
--- a/tests/test_context_relevance.py
+++ b/tests/test_context_relevance.py
@@ -1,0 +1,19 @@
+import unittest
+from multi_layer_ood import ContextRelevanceAssessor, ResponseVerificationConfig
+
+
+class TestContextRelevanceAssessor(unittest.TestCase):
+    def setUp(self):
+        self.assessor = ContextRelevanceAssessor(ResponseVerificationConfig())
+
+    def test_identical_text_high_similarity(self):
+        scored = self.assessor.score_passages("apple", ["apple"])
+        self.assertGreaterEqual(scored[0][1], 0.95)
+
+    def test_different_text_low_similarity(self):
+        scored = self.assessor.score_passages("apple", ["banana"])
+        self.assertLess(scored[0][1], 0.95)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add detailed debug logs to ContextRelevanceAssessor showing embedding info and similarity scores
- provide deterministic fallback warning when transformer model fails to load
- add unit tests verifying high similarity for identical text and low similarity for different text

## Testing
- `pytest tests/test_context_relevance.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894c76de1fc8322b17e8a53e74fef28