### PR TITLE
Integrate graph semantics into OOD detection

### DIFF
--- a/domain_concept_registry.py
+++ b/domain_concept_registry.py
@@ -1,0 +1,64 @@
+import logging
+import re
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+from sklearn.feature_extraction.text import HashingVectorizer
+try:
+    from sentence_transformers import SentenceTransformer
+    _HAS_TRANSFORMER = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_TRANSFORMER = False
+
+logger = logging.getLogger(__name__)
+
+
+class DomainConceptRegistry:
+    """Registry of known domain concepts and their embeddings."""
+
+    def __init__(self, concepts: Sequence[str], synonyms: Dict[str, str] | None = None):
+        self.concepts = [c.lower() for c in concepts]
+        self.synonyms = {k.lower(): v.lower() for k, v in (synonyms or {}).items()}
+        if _HAS_TRANSFORMER:
+            model_name = "sentence-transformers/all-MiniLM-L6-v2"
+            try:
+                self._embedder = SentenceTransformer(model_name)
+                self._use_transformer = True
+            except Exception as exc:  # pragma: no cover - network failure fallback
+                logger.warning("Falling back to HashingVectorizer embeddings due to: %s", exc)
+                self._use_transformer = False
+                self._vectorizer = HashingVectorizer(n_features=384, alternate_sign=False, norm="l2")
+        else:  # pragma: no cover - sklearn fallback
+            self._use_transformer = False
+            self._vectorizer = HashingVectorizer(n_features=384, alternate_sign=False, norm="l2")
+        self.embeddings = {c: self._embed(c) for c in self.concepts}
+
+    def _embed(self, text: str) -> np.ndarray:
+        if self._use_transformer:
+            return self._embedder.encode(text, normalize_embeddings=True)
+        return self._vectorizer.transform([text]).toarray()[0]
+
+    def resolve(self, term: str) -> str:
+        term_l = term.lower()
+        return self.synonyms.get(term_l, term_l)
+
+    def match(self, term: str) -> Tuple[str, float]:
+        """Return the closest concept and similarity score."""
+        term = self.resolve(term)
+        emb = self._embed(term)
+        best, best_score = "", 0.0
+        for concept, c_emb in self.embeddings.items():
+            denom = (np.linalg.norm(emb) * np.linalg.norm(c_emb)) or 1.0
+            score = float(np.dot(emb, c_emb) / denom)
+            if score > best_score:
+                best, best_score = concept, score
+        return best, best_score
+
+    def extract_from_query(self, query: str) -> List[str]:
+        tokens = re.findall(r"\w+", query.lower())
+        matched: List[str] = []
+        for tok in tokens:
+            concept, score = self.match(tok)
+            if score >= 0.8:
+                matched.append(concept)
+        return matched

--- a/graph_semantic_analyzer.py
+++ b/graph_semantic_analyzer.py
@@ -1,0 +1,46 @@
+import logging
+import re
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
+from domain_concept_registry import DomainConceptRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class GraphSemanticAnalyzer:
+    """Analyze graph relationships for semantic coherence."""
+
+    def __init__(self, registry: DomainConceptRegistry):
+        self.registry = registry
+
+    def analyze(self, query: str, graph_results: Sequence[str]) -> Tuple[float, List[str], List[str]]:
+        tokens = re.findall(r"\w+", query.lower())
+        matched: List[str] = []
+        match_scores: List[float] = []
+        for tok in tokens:
+            concept, score = self.registry.match(tok)
+            if score >= 0.8:
+                matched.append(concept)
+                match_scores.append(score)
+        entity_counts = {e: 0 for e in matched}
+        neighborhood: set[str] = set()
+        for rel in graph_results:
+            parts = [p.strip().lower() for p in re.split(r"->|--|,", rel) if p.strip()]
+            if len(parts) < 2:
+                continue
+            for node in parts:
+                if node in entity_counts:
+                    entity_counts[node] += 1
+                else:
+                    neighborhood.add(node)
+        centrality = (sum(entity_counts.values()) / (len(graph_results) or 1))
+        density = len(graph_results) / (len(matched) + 1)
+        semantic = float(np.mean(match_scores)) if match_scores else 0.0
+        graph_score = (centrality + density + semantic) / 3
+        logger.debug(
+            "Graph semantics: score=%.3f centrality=%.3f density=%.3f semantic=%.3f", 
+            graph_score, centrality, density, semantic,
+        )
+        return graph_score, matched, list(neighborhood)

--- a/query_normalizer.py
+++ b/query_normalizer.py
@@ -1,0 +1,28 @@
+import logging
+from typing import List, Tuple
+
+from domain_concept_registry import DomainConceptRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class QueryNormalizer:
+    """Normalize queries using domain vocabulary."""
+
+    def __init__(self, registry: DomainConceptRegistry):
+        self.registry = registry
+
+    def normalize(self, query: str) -> Tuple[str, List[str]]:
+        tokens = query.split()
+        normalized: List[str] = []
+        matched: List[str] = []
+        for tok in tokens:
+            concept, score = self.registry.match(tok)
+            if score >= 0.8:
+                normalized.append(concept)
+                matched.append(concept)
+            else:
+                normalized.append(tok)
+        normalized_query = " ".join(normalized)
+        logger.debug("Normalized query '%s' -> '%s'", query, normalized_query)
+        return normalized_query, matched


### PR DESCRIPTION
## Summary
- add `DomainConceptRegistry`, `QueryNormalizer`, and `GraphSemanticAnalyzer` to leverage knowledge graph concepts and embeddings
- extend `DomainBoundaryDetector` with semantic graph coverage assessment and weighted scoring for domain decisions
- refactor `MultiLayerOODDetector` pipeline to use normalized queries, graph-aware relevance boosting, and graph-based generation overrides

## Testing
- `pytest tests/test_multi_layer_ood.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68972d2a6e7883229617fc6753ba8eab