### PR TITLE
Align OOD detector call with updated signature

### DIFF
--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -1281,14 +1281,13 @@ class RAGPipeline:
         ]
         graph_count = len(hybrid_results["graph_results"])
         similarity = self._embedding_similarity(query)
-        graph_connectivity = graph_count / max(len(retrieved_passages), 1)
 
         detection = self.ood_detector.process(
             query=query,
             similarity=similarity,
-            graph_connectivity=graph_connectivity,
             retrieved_passages=retrieved_passages,
             token_probs=[0.9],
+            graph_results=hybrid_results["graph_results"],
         )
 
         logger.debug("Multi-layer OOD detection result: %s", detection)


### PR DESCRIPTION
## Summary
- fix RAG pipeline to call MultiLayerOODDetector.process without legacy `graph_connectivity`
- forward graph search results directly so graph semantics handled internally

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68973681bb608322829666e0a5b79199