### PR TITLE
Reduce Thinking logs during queries

### DIFF
--- a/domain_concept_registry.py
+++ b/domain_concept_registry.py
@@ -35,9 +35,8 @@ class DomainConceptRegistry:
 
     def _embed(self, text: str) -> np.ndarray:
         if self._use_transformer:
-
-            print("🔍 Thinking...")
-            emb = np.asarray(
+            logger.debug("Embedding text '%s'", text)
+            return np.asarray(
                 self._embedder.encode(
                     text,
                     normalize_embeddings=True,
@@ -46,10 +45,6 @@ class DomainConceptRegistry:
                 ),
                 dtype=np.float32,
             )
-            print("✅ Analysis complete")
-            return emb
-
-            return self._embedder.encode(text, normalize_embeddings=True, )
 
         return self._vectorizer.transform([text]).toarray()[0]
 

--- a/multi_layer_ood.py
+++ b/multi_layer_ood.py
@@ -262,8 +262,7 @@ class ContextRelevanceAssessor:
     def _get_embedding(self, text: str) -> np.ndarray:
         if text not in self._embedding_cache:
             if self._use_transformer:
-
-                print("🔍 Thinking...")
+                self.logger.debug("Embedding text '%s'", text)
                 emb = np.asarray(
                     self._embedder.encode(
                         text,
@@ -273,10 +272,6 @@ class ContextRelevanceAssessor:
                     ),
                     dtype=np.float32,
                 )
-                print("✅ Analysis complete")
-
-                emb = self._embedder.encode(text, normalize_embeddings=True, )
-
                 self.logger.debug("Embedding for '%s' shape=%s", text, emb.shape)
             else:  # pragma: no cover - simple hashing fallback
                 emb = self._vectorizer.transform([text]).toarray()[0]


### PR DESCRIPTION
## Summary
- Replace verbose `print` statements in embedding helpers with debug logs
- Prevent multiple "Thinking..." messages during concept and relevance embedding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897792be46c8322ae6b9ab5d04d0cfd