### PR TITLE
Simplify CLI output and suppress info logs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,7 +50,7 @@ chunk_processing:
 
 # Logging Configuration
 logging:
-  level: INFO
+  level: WARNING
   enable_debug_components: false
   components:
     httpcore: WARNING
@@ -59,10 +59,10 @@ logging:
     neo4j: WARNING
     httpx: WARNING
     sentence_transformers: WARNING
-    multi_layer_ood: INFO
-    graph_semantic_analyzer: INFO
-    query_normalizer: INFO
-    main: INFO
+    multi_layer_ood: WARNING
+    graph_semantic_analyzer: WARNING
+    query_normalizer: WARNING
+    main: WARNING
   file: "logs/rag_system.log"
   suppress_warnings: true
   show_progress_bars: false

--- a/processing/hybrid_pipeline.py
+++ b/processing/hybrid_pipeline.py
@@ -48,7 +48,7 @@ class HybridPipeline:
         self.legacy_pipeline = None
 
         # Setup logging
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.WARNING)
         logger.info("HybridPipeline instance created")
 
     def _is_factual(self, question: str) -> bool:

--- a/processing/knowledge_graph.py
+++ b/processing/knowledge_graph.py
@@ -344,7 +344,7 @@ def build_knowledge_graph(
     pruned based on a confidence threshold.
     """
 
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
 
     if load_documents_from_folder is None:
         logger.error("domain_loader module not available")

--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -60,13 +60,13 @@ logger = logging.getLogger(__name__)
 
 def setup_logging(config):
     """Configure logging based on config settings"""
-    root_level_name = config.get('logging', {}).get('level', 'INFO')
-    root_level = getattr(logging, root_level_name.upper(), logging.INFO)
+    root_level_name = config.get('logging', {}).get('level', 'WARNING')
+    root_level = getattr(logging, root_level_name.upper(), logging.WARNING)
     logging.getLogger().setLevel(root_level)
 
     components = config.get('logging', {}).get('components', {})
     for component, level in components.items():
-        log_level = getattr(logging, level.upper(), logging.INFO)
+        log_level = getattr(logging, level.upper(), logging.WARNING)
         logging.getLogger(component).setLevel(log_level)
 
     if config.get('logging', {}).get('enable_debug_components', False):
@@ -1490,25 +1490,14 @@ def main():
         pipeline.populate_knowledge_graph()
 
     # PHASE 2: Interactive Q&A with hybrid retrieval
-    print("\n💬 Hybrid Q&A (Vector + Knowledge Graph)")
-    print("Ask questions about partnerships, collaborations, or general content.")
-
     while True:
         query = input("\n❓ You: ").strip()
         if query.lower() == 'quit':
             break
 
         print("🔍 Thinking...")
-        start_time = time.time()
         result = pipeline.query_with_graph(query)
-        elapsed = time.time() - start_time
-        print("✅ Ready")
-
-        print(f"\n💬 Answer (in {elapsed:.2f}s):")
-        print("-" * 60)
         print(result["answer"])
-        print(f"\n📊 Retrieved: {result['vector_results']} vector + {result['graph_results']} graph results")
-        print("-" * 60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- streamline interactive Q&A loop to show only query, thinking indicator, and answer
- default all logging to WARNING to suppress INFO messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68978c89f71c832296ba8d3e1bf991cb