### PR TITLE
Fix Neo4j entity search and relax graph connectivity threshold

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -83,7 +83,7 @@ ood:
 ood_detection:
   enabled: true
   similarity_threshold: 0.15
-  graph_connectivity_threshold: 0.6
+  graph_connectivity_threshold: 0.1
   context_quality_threshold: 0.7
   generation_confidence_threshold: 0.4
 

--- a/multi_layer_ood.py
+++ b/multi_layer_ood.py
@@ -51,7 +51,7 @@ class AbstentionConfig:
 class OODDetectionConfig:
     enabled: bool = True
     similarity_threshold: float = 0.15
-    graph_connectivity_threshold: float = 0.6
+    graph_connectivity_threshold: float = 0.1
     context_quality_threshold: float = 0.7
     generation_confidence_threshold: float = 0.8
     keywords: KeywordTiers = field(default_factory=KeywordTiers)

--- a/processing/knowledge_graph.py
+++ b/processing/knowledge_graph.py
@@ -129,6 +129,7 @@ def query_knowledge_graph(query: str, config: Config) -> List[Dict[str, Any]]:
     cypher = (
         "MATCH (n)-[r*1..2]-(m) "
         "WHERE toLower(n.name) CONTAINS toLower($q) "
+        "   OR toLower(m.name) CONTAINS toLower($q) "
         "RETURN n, m LIMIT 20"
     )
     records: List[Dict[str, Any]] = []

--- a/tests/test_multi_layer_ood.py
+++ b/tests/test_multi_layer_ood.py
@@ -31,7 +31,7 @@ class TestMultiLayerOOD(unittest.TestCase):
         )
         cfg = OODDetectionConfig(
             similarity_threshold=0.1,
-            graph_connectivity_threshold=0.6,
+            graph_connectivity_threshold=0.1,
             generation_confidence_threshold=0.5,
             keywords=keywords,
             quality_gates=quality,

--- a/tests/test_processing_graph.py
+++ b/tests/test_processing_graph.py
@@ -16,6 +16,7 @@ def test_query_knowledge_graph_uses_extracted_entity():
     cypher = (
         "MATCH (n)-[r*1..2]-(m) "
         "WHERE toLower(n.name) CONTAINS toLower($q) "
+        "   OR toLower(m.name) CONTAINS toLower($q) "
         "RETURN n, m LIMIT 20"
     )
     mock_session.run.assert_called_once_with(cypher, q='Scania')

--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -107,7 +107,7 @@ def load_ood_config() -> OODDetectionConfig:
     return OODDetectionConfig(
         enabled=data.get("enabled", True),
         similarity_threshold=data.get("similarity_threshold", 0.15),
-        graph_connectivity_threshold=data.get("graph_connectivity_threshold", 0.6),
+        graph_connectivity_threshold=data.get("graph_connectivity_threshold", 0.1),
         context_quality_threshold=data.get("context_quality_threshold", 0.7),
         generation_confidence_threshold=data.get("generation_confidence_threshold", 0.8),
         keywords=keywords,


### PR DESCRIPTION
## Summary
- Correct Neo4j query to match entities on either side of relationships
- Temporarily lower graph connectivity threshold to 0.1 across config and defaults
- Update tests accordingly

## Testing
- `pytest`
- `python - <<'PY'
from weaviate_rag_pipeline_transformers import *
from processing.knowledge_graph import query_knowledge_graph
from backend.config import Config

cfg = Config()
try:
    res = query_knowledge_graph('evidence theory', cfg)
    print('Results:', res)
except Exception as e:
    print('Error:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689798855a548322a1eb5e8022045a94