### PR TITLE
Suppress Neo4j deprecation notifications

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,7 @@ logging:
     anthropic: WARNING
     urllib3: WARNING
     neo4j: WARNING
+    neo4j.notifications: ERROR
     httpx: WARNING
     sentence_transformers: WARNING
     multi_layer_ood: WARNING

--- a/weaviate_rag_pipeline_transformers.py
+++ b/weaviate_rag_pipeline_transformers.py
@@ -56,6 +56,7 @@ CONFIG = Config()
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
+logging.getLogger('neo4j.notifications').setLevel(logging.ERROR)
 
 
 def setup_logging(config):
@@ -63,6 +64,7 @@ def setup_logging(config):
     root_level_name = config.get('logging', {}).get('level', 'WARNING')
     root_level = getattr(logging, root_level_name.upper(), logging.WARNING)
     logging.getLogger().setLevel(root_level)
+    logging.getLogger('neo4j.notifications').setLevel(logging.ERROR)
 
     components = config.get('logging', {}).get('components', {})
     for component, level in components.items():


### PR DESCRIPTION
## Summary
- silence neo4j deprecation warnings by forcing neo4j.notifications logger to ERROR
- add configurable suppression for neo4j.notifications logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987c71924483228282bb0b14787107