### PR TITLE
Add Flask web interface and shared RAG backend

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,56 @@
+"""Flask web application providing API access to the RAG backend."""
+from __future__ import annotations
+
+import json
+import time
+from flask import Flask, request, jsonify, Response, render_template
+
+from rag_backend import RAGBackend
+
+app = Flask(__name__, static_folder="static", template_folder="templates")
+backend: RAGBackend | None = None
+
+
+def get_backend() -> RAGBackend:
+    global backend
+    if backend is None:
+        backend = RAGBackend()
+    return backend
+
+
+@app.route("/api/health")
+def health() -> Response:
+    """Simple health check endpoint."""
+    return jsonify({"status": "ok"})
+
+
+@app.route("/api/stats")
+def stats() -> Response:
+    """Return static knowledge graph statistics."""
+    return jsonify({"relationships": 700, "entities": 954})
+
+
+@app.route("/api/query", methods=["POST"])
+def query() -> Response:
+    data = request.get_json(force=True)
+    user_query = data.get("query", "")
+
+    def generate():
+        result = get_backend().query(user_query)["answer"]
+        # Stream word by word to emulate ChatGPT typing
+        for token in result.split():
+            payload = json.dumps({"token": token + " "})
+            yield f"data: {payload}\n\n"
+            time.sleep(0.05)
+        yield "data: [DONE]\n\n"
+
+    return Response(generate(), mimetype="text/event-stream")
+
+
+@app.route("/")
+def index() -> str:
+    return render_template("index.html")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    app.run(host="0.0.0.0", port=8000, debug=False)

--- a/rag_backend.py
+++ b/rag_backend.py
@@ -1,0 +1,85 @@
+"""Shared backend logic for RAG system.
+
+This module exposes a `RAGBackend` class that wraps the existing
+`RAGPipeline` from `weaviate_rag_pipeline_transformers` so it can be
+reused by both the command line interface and the new web application.
+
+The implementation mirrors the setup performed in the CLI's `main`
+function but packages it in a class that can be instantiated and queried
+programmatically.
+"""
+from __future__ import annotations
+
+import json
+import time
+import subprocess
+from typing import Optional
+
+import yaml
+
+from haystack.components.embedders import SentenceTransformersTextEmbedder
+from haystack_integrations.document_stores.weaviate import WeaviateDocumentStore
+from haystack_integrations.components.retrievers.weaviate import (
+    WeaviateEmbeddingRetriever,
+)
+
+# Reuse the existing pipeline and utilities from the CLI module.
+from weaviate_rag_pipeline_transformers import (
+    RAGPipeline,
+    check_docker_containers,
+    setup_logging,
+    wait_for_weaviate,
+)
+
+
+class RAGBackend:
+    """Backend helper that wraps the heavy RAG pipeline."""
+
+    def __init__(self, config_path: str = "config.yaml", force_rebuild: bool = False):
+        # Load configuration and set up logging exactly as the CLI does.
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+        setup_logging(config)
+
+        self._ensure_infrastructure()
+
+        if not wait_for_weaviate():
+            raise RuntimeError("Weaviate not responding. Check docker-compose logs.")
+
+        # Build Haystack components
+        self.document_store = WeaviateDocumentStore(url="http://localhost:8080")
+        self.text_embedder = SentenceTransformersTextEmbedder(
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            progress_bar=False,
+            encode_kwargs={"convert_to_tensor": False},
+        )
+        self.text_embedder.warm_up()
+        retriever = WeaviateEmbeddingRetriever(document_store=self.document_store)
+
+        # Initialize pipeline from the original module
+        self.pipeline = RAGPipeline(self.document_store, retriever, self.text_embedder)
+
+        # Process documents and populate knowledge graph
+        self.pipeline.process_documents_intelligently()
+        if force_rebuild:
+            self.pipeline.force_rebuild_graph()
+        else:
+            self.pipeline.populate_knowledge_graph()
+
+    def _ensure_infrastructure(self) -> None:
+        """Ensure required Docker services are running."""
+        if check_docker_containers():
+            return
+        try:
+            subprocess.run(["docker-compose", "up", "-d"], check=True)
+            # Give services a moment to start
+            time.sleep(30)
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - runtime environment
+            raise RuntimeError("Failed to start Docker containers") from exc
+
+    def query(self, query: str) -> dict:
+        """Execute a query through the RAG pipeline."""
+        return self.pipeline.query_with_graph(query)
+
+
+__all__ = ["RAGBackend"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,9 @@ tqdm>=4.64.0
 # Testing
 pytest>=7.0.0
 
+# Web application
+Flask>=3.0.0
+
 # Neo4j driver for knowledge graph integration
 neo4j>=5.16.0
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,103 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: #f5f7fb;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  padding: 10px 20px;
+  background: #16335b;
+  color: #fff;
+}
+.logo {
+  margin-right: 10px;
+  font-weight: bold;
+  font-size: 1.2em;
+}
+
+.stats {
+  padding: 10px 20px;
+  background: #e6edf5;
+}
+
+.suggestions {
+  display: flex;
+  gap: 10px;
+  padding: 10px 20px;
+}
+
+.suggestion {
+  padding: 6px 12px;
+  border: none;
+  background: #16335b;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.chat {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.message {
+  max-width: 80%;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.user {
+  align-self: flex-end;
+  background: #d1e4ff;
+}
+
+.bot {
+  align-self: flex-start;
+  background: #ffffff;
+  border: 1px solid #ddd;
+}
+
+.input-area {
+  display: flex;
+  padding: 10px;
+  background: #e6edf5;
+}
+
+.input-area input {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.input-area button {
+  margin-left: 10px;
+  padding: 8px 16px;
+  background: #16335b;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.thinking {
+  text-align: center;
+  padding: 10px;
+  font-style: italic;
+}
+
+.hidden { display: none; }
+
+@media (max-width: 600px) {
+  .chat { padding: 10px; }
+  .suggestions { flex-wrap: wrap; }
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,67 @@
+const chat = document.getElementById('chat');
+const form = document.getElementById('chat-form');
+const input = document.getElementById('user-input');
+const thinking = document.getElementById('thinking');
+
+actionButtons();
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const query = input.value.trim();
+  if (!query) return;
+  addMessage(query, 'user');
+  input.value = '';
+  sendQuery(query);
+});
+
+function actionButtons() {
+  document.querySelectorAll('.suggestion').forEach(btn => {
+    btn.addEventListener('click', () => {
+      input.value = btn.textContent;
+      form.dispatchEvent(new Event('submit'));
+    });
+  });
+}
+
+function addMessage(text, role) {
+  const div = document.createElement('div');
+  div.className = `message ${role}`;
+  div.textContent = text;
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+}
+
+async function sendQuery(query) {
+  thinking.classList.remove('hidden');
+  addMessage('', 'bot');
+  const last = chat.lastElementChild;
+
+  const response = await fetch('/api/query', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query })
+  });
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let botText = '';
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value, { stream: true });
+    chunk.split('\n').forEach(line => {
+      if (line.startsWith('data:')) {
+        const data = line.replace('data:','').trim();
+        if (data === '[DONE]') return;
+        try {
+          const obj = JSON.parse(data);
+          botText += obj.token;
+          last.textContent = botText;
+          chat.scrollTop = chat.scrollHeight;
+        } catch {}
+      }
+    });
+  }
+  thinking.classList.add('hidden');
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>I2Connect RAG Chat</title>
+  <link rel="stylesheet" href="/static/css/style.css" />
+</head>
+<body>
+  <header class="header">
+    <div class="logo">🚗 I2Connect Knowledge Expert</div>
+    <!-- Replace the div above with <img src="/static/img/logo.png" alt="I2Connect logo" /> to add a custom logo -->
+    <h1>I2Connect RAG Assistant</h1>
+  </header>
+
+  <section class="stats">
+    <p><strong>Knowledge Graph:</strong> 700 relationships, 954 entities</p>
+  </section>
+
+  <section class="suggestions">
+    <button class="suggestion">Evidence Theory</button>
+    <button class="suggestion">Risk Assessment</button>
+    <button class="suggestion">Graph Database</button>
+  </section>
+
+  <main id="chat" class="chat"></main>
+
+  <div id="thinking" class="thinking hidden">🔍 Thinking...</div>
+
+  <form id="chat-form" class="input-area">
+    <input id="user-input" type="text" placeholder="Type your question..." autocomplete="off" />
+    <button type="submit">Send</button>
+  </form>
+
+  <script src="/static/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose RAG pipeline through a Flask API with health, stats, and streaming query endpoints
- add reusable `RAGBackend` module to bootstrap existing `RAGPipeline`
- create modern ChatGPT-style frontend with I2Connect branding and suggested queries
- document new Flask dependency
- replace image logo with CSS-styled `🚗 I2Connect Knowledge Expert` text logo

## Testing
- `pytest`
- `python -m flask --app app run --port=5000`
- `curl -s http://localhost:5000/ | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68987fa7370083228c669efec30ccc3b