### PR TITLE
Improve frontend response formatting

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -26,9 +26,45 @@ function actionButtons() {
 function addMessage(text, role) {
   const div = document.createElement('div');
   div.className = `message ${role}`;
-  div.textContent = text;
+  if (role === 'bot') {
+    div.innerHTML = formatResponse(text);
+  } else {
+    div.textContent = text;
+  }
   chat.appendChild(div);
   chat.scrollTop = chat.scrollHeight;
+}
+
+function formatResponse(text) {
+  let formatted = text;
+
+  // Convert numbered headings like "1. Title:" to <h4>
+  formatted = formatted.replace(/^(\d+\.\s+.+?:)\s*$/gm, '<h4>$1</h4>');
+
+  // Convert standalone headings ending with a colon
+  formatted = formatted.replace(/^([A-Za-z][^:\n]+:)\s*$/gm, '<h4>$1</h4>');
+
+  // Bullet points -> list items
+  formatted = formatted.replace(/^[-*•]\s+(.+?)$/gm, '<li>$1</li>');
+
+  // Wrap consecutive list items in <ul>
+  formatted = formatted.replace(/(<li>.*?<\/li>)+/gs, match => `<ul>${match}</ul>`);
+
+  // Double line breaks -> paragraph breaks
+  formatted = formatted.replace(/\n\n+/g, '</p><p>');
+
+  // Single line breaks -> <br>
+  formatted = formatted.replace(/\n/g, '<br>');
+
+  // Ensure wrapped in paragraph tags when needed
+  if (!formatted.startsWith('<h4>') && !formatted.startsWith('<ul>')) {
+    formatted = '<p>' + formatted;
+  }
+  if (!formatted.endsWith('</p>') && !formatted.endsWith('</ul>')) {
+    formatted = formatted + '</p>';
+  }
+
+  return formatted;
 }
 
 async function sendQuery(query) {
@@ -57,7 +93,7 @@ async function sendQuery(query) {
         try {
           const obj = JSON.parse(data);
           botText += obj.token;
-          last.textContent = botText;
+          last.innerHTML = formatResponse(botText);
           chat.scrollTop = chat.scrollHeight;
         } catch {}
       }


### PR DESCRIPTION
## Summary
- Format bot responses with headings, bullet lists, and paragraphs
- Render formatted text during streaming and when adding bot messages

## Testing
- `pytest`
- `python app.py` (startup)


------
https://chatgpt.com/codex/tasks/task_e_6898ce9f3bb88322889af10e92778d0c