### PR TITLE
Improve response formatting and cache busting

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,7 +49,7 @@ def query() -> Response:
 
 @app.route("/")
 def index() -> str:
-    return render_template("index.html")
+    return render_template("index.html", version=int(time.time()))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,16 +3,18 @@ const form = document.getElementById('chat-form');
 const input = document.getElementById('user-input');
 const thinking = document.getElementById('thinking');
 
-actionButtons();
+if (chat && form && input && thinking) {
+  actionButtons();
 
-form.addEventListener('submit', (e) => {
-  e.preventDefault();
-  const query = input.value.trim();
-  if (!query) return;
-  addMessage(query, 'user');
-  input.value = '';
-  sendQuery(query);
-});
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const query = input.value.trim();
+    if (!query) return;
+    addMessage(query, 'user');
+    input.value = '';
+    sendQuery(query);
+  });
+}
 
 function actionButtons() {
   document.querySelectorAll('.suggestion').forEach(btn => {
@@ -36,16 +38,17 @@ function addMessage(text, role) {
 }
 
 function formatResponse(text) {
+  console.log('Original text:', text);
   let formatted = text;
 
-  // Convert numbered headings like "1. Title:" to <h4>
-  formatted = formatted.replace(/^(\d+\.\s+.+?:)\s*$/gm, '<h4>$1</h4>');
+  // Convert numbered headings like "1. Title:" to <h4> (remove trailing colon)
+  formatted = formatted.replace(/^(\d+\.\s+[^:\n]+):\s*$/gm, '<h4>$1</h4>');
 
   // Convert standalone headings ending with a colon
-  formatted = formatted.replace(/^([A-Za-z][^:\n]+:)\s*$/gm, '<h4>$1</h4>');
+  formatted = formatted.replace(/^([A-Za-z][^:\n]+):\s*$/gm, '<h4>$1</h4>');
 
   // Bullet points -> list items
-  formatted = formatted.replace(/^[-*•]\s+(.+?)$/gm, '<li>$1</li>');
+  formatted = formatted.replace(/^\s*[-*•]\s+(.+?)$/gm, '<li>$1</li>');
 
   // Wrap consecutive list items in <ul>
   formatted = formatted.replace(/(<li>.*?<\/li>)+/gs, match => `<ul>${match}</ul>`);
@@ -64,6 +67,7 @@ function formatResponse(text) {
     formatted = formatted + '</p>';
   }
 
+  console.log('Formatted text:', formatted);
   return formatted;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -511,6 +511,7 @@
         </div>
     </div>
 
+    <script src="{{ url_for('static', filename='js/app.js') }}?v={{ version }}"></script>
     <script>
         // Conversation memory
         let conversationHistory = [];
@@ -612,41 +613,36 @@
         }
 
         function formatResponse(text) {
-            // Enhanced formatting for better readability
+            console.log('Original text:', text);
             let formatted = text;
-            
-            // Convert numbered lists with periods to HTML
-            formatted = formatted.replace(/^(\d+)\.\s+(.+?)(?=\n|$)/gm, '<h4>$1. $2</h4>');
-            
-            // Convert standalone headings (words followed by colon)
-            formatted = formatted.replace(/^([A-Za-z][^:\n]+):\s*$/gm, '<h4>$1:</h4>');
-            
-            // Convert bullet points to HTML lists
-            formatted = formatted.replace(/^[-•]\s+(.+?)(?=\n|$)/gm, '<li>$1</li>');
-            
-            // Wrap consecutive list items in ul tags
-            formatted = formatted.replace(/(<li>.*?<\/li>)(\s*<li>.*?<\/li>)*/gs, '<ul>$&</ul>');
-            
-            // Convert double line breaks to paragraph breaks
+
+            // Convert numbered headings like "1. Title:" to <h4>
+            formatted = formatted.replace(/^(\d+\.\s+[^:\n]+):\s*$/gm, '<h4>$1</h4>');
+
+            // Convert standalone headings ending with a colon
+            formatted = formatted.replace(/^([A-Za-z][^:\n]+):\s*$/gm, '<h4>$1</h4>');
+
+            // Bullet points -> list items
+            formatted = formatted.replace(/^\s*[-*•]\s+(.+?)$/gm, '<li>$1</li>');
+
+            // Wrap consecutive list items in <ul>
+            formatted = formatted.replace(/(<li>.*?<\/li>)+/gs, match => `<ul>${match}</ul>`);
+
+            // Double line breaks -> paragraph breaks
             formatted = formatted.replace(/\n\n+/g, '</p><p>');
-            
-            // Convert single line breaks to br tags within paragraphs
+
+            // Single line breaks -> <br>
             formatted = formatted.replace(/\n/g, '<br>');
-            
-            // Wrap in paragraph tags if not already formatted
-            if (!formatted.includes('<h4>') && !formatted.includes('<ul>') && !formatted.includes('<p>')) {
-                formatted = '<p>' + formatted + '</p>';
-            } else {
-                // Add opening paragraph tag if content doesn't start with a heading or list
-                if (!formatted.startsWith('<h4>') && !formatted.startsWith('<ul>')) {
-                    formatted = '<p>' + formatted;
-                }
-                // Add closing paragraph tag if needed
-                if (!formatted.endsWith('</p>') && !formatted.endsWith('</ul>')) {
-                    formatted = formatted + '</p>';
-                }
+
+            // Ensure wrapped in paragraph tags when needed
+            if (!formatted.startsWith('<h4>') && !formatted.startsWith('<ul>')) {
+                formatted = '<p>' + formatted;
             }
-            
+            if (!formatted.endsWith('</p>') && !formatted.endsWith('</ul>')) {
+                formatted = formatted + '</p>';
+            }
+
+            console.log('Formatted text:', formatted);
             return formatted;
         }
 


### PR DESCRIPTION
## Summary
- Format streamed responses into headings, bullet lists, and paragraphs
- Add debug logging to inspect original vs formatted text
- Bust browser cache by versioning `app.js`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d91859908322b376ea552491834a