### PR TITLE
Improve web response formatting and streaming

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import time
+import re
 from flask import Flask, request, jsonify, Response, render_template
 
 from rag_backend import RAGBackend
@@ -37,11 +38,11 @@ def query() -> Response:
 
     def generate():
         result = get_backend().query(user_query)["answer"]
-        # Stream word by word to emulate ChatGPT typing
-        for token in result.split():
-            payload = json.dumps({"content": token + " "})
+        # Preserve whitespace and newlines while streaming
+        for token in re.findall(r"\S+\s*", result):
+            payload = json.dumps({"token": token})
             yield f"data: {payload}\n\n"
-            time.sleep(0.05)
+            time.sleep(0.02)
         yield "data: [DONE]\n\n"
 
     return Response(generate(), mimetype="text/event-stream")

--- a/rag_backend.py
+++ b/rag_backend.py
@@ -77,9 +77,17 @@ class RAGBackend:
         except subprocess.CalledProcessError as exc:  # pragma: no cover - runtime environment
             raise RuntimeError("Failed to start Docker containers") from exc
 
+    def _format_answer(self, text: str) -> str:
+        """Normalize whitespace and preserve paragraph breaks."""
+        lines = [line.rstrip() for line in text.splitlines()]
+        return "\n".join(line for line in lines if line)
+
     def query(self, query: str) -> dict:
         """Execute a query through the RAG pipeline."""
-        return self.pipeline.query_with_graph(query)
+        result = self.pipeline.query_with_graph(query)
+        if "answer" in result:
+            result["answer"] = self._format_answer(result["answer"])
+        return result
 
 
 __all__ = ["RAGBackend"]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -101,3 +101,28 @@ body {
   .chat { padding: 10px; }
   .suggestions { flex-wrap: wrap; }
 }
+
+/* Improved typography for bot responses */
+.bot p,
+.message-content p {
+  margin: 0.5em 0;
+  line-height: 1.6;
+}
+
+.bot ul,
+.bot ol,
+.message-content ul,
+.message-content ol {
+  margin: 0.5em 0 0.5em 1.5em;
+  padding-left: 1.2em;
+}
+
+.bot li,
+.message-content li {
+  margin-bottom: 0.25em;
+}
+
+.bot strong,
+.message-content strong {
+  font-weight: 600;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -47,11 +47,23 @@ function formatResponse(text) {
   // Convert standalone headings ending with a colon
   formatted = formatted.replace(/^([A-Za-z][^:\n]+):\s*$/gm, '<h4>$1</h4>');
 
-  // Bullet points -> list items
-  formatted = formatted.replace(/^\s*[-*•]\s+(.+?)$/gm, '<li>$1</li>');
+  // Bold **text** patterns
+  formatted = formatted.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
 
-  // Wrap consecutive list items in <ul>
-  formatted = formatted.replace(/(<li>.*?<\/li>)+/gs, match => `<ul>${match}</ul>`);
+  // Numbered list items (e.g., "1. item")
+  formatted = formatted.replace(/^\s*\d+\.\s+(.+?)$/gm, '<li class="numbered">$1</li>');
+
+  // Bullet points -> list items
+  formatted = formatted.replace(/^\s*[-*•]\s+(.+?)$/gm, '<li class="bullet">$1</li>');
+
+  // Wrap consecutive numbered items in <ol>
+  formatted = formatted.replace(/(<li class="numbered">.*?<\/li>\s*)+/gs, match => `<ol>${match}</ol>`);
+
+  // Wrap consecutive bullet items in <ul>
+  formatted = formatted.replace(/(<li class="bullet">.*?<\/li>\s*)+/gs, match => `<ul>${match}</ul>`);
+
+  // Clean up temporary classes
+  formatted = formatted.replace(/<li class="(?:numbered|bullet)">/g, '<li>');
 
   // Double line breaks -> paragraph breaks
   formatted = formatted.replace(/\n\n+/g, '</p><p>');

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>I2Connect Knowledge Expert</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v={{ version }}">
     <style>
         * {
             margin: 0;
@@ -589,8 +590,8 @@
                                 
                                 try {
                                     const parsed = JSON.parse(data);
-                                    if (parsed.content) {
-                                        accumulatedText += parsed.content;
+                                    if (parsed.token) {
+                                        accumulatedText += parsed.token;
                                         updateMessage(messageId, formatResponse(accumulatedText));
                                     }
                                 } catch (e) {
@@ -612,39 +613,7 @@
             }
         }
 
-        function formatResponse(text) {
-            console.log('Original text:', text);
-            let formatted = text;
-
-            // Convert numbered headings like "1. Title:" to <h4>
-            formatted = formatted.replace(/^(\d+\.\s+[^:\n]+):\s*$/gm, '<h4>$1</h4>');
-
-            // Convert standalone headings ending with a colon
-            formatted = formatted.replace(/^([A-Za-z][^:\n]+):\s*$/gm, '<h4>$1</h4>');
-
-            // Bullet points -> list items
-            formatted = formatted.replace(/^\s*[-*•]\s+(.+?)$/gm, '<li>$1</li>');
-
-            // Wrap consecutive list items in <ul>
-            formatted = formatted.replace(/(<li>.*?<\/li>)+/gs, match => `<ul>${match}</ul>`);
-
-            // Double line breaks -> paragraph breaks
-            formatted = formatted.replace(/\n\n+/g, '</p><p>');
-
-            // Single line breaks -> <br>
-            formatted = formatted.replace(/\n/g, '<br>');
-
-            // Ensure wrapped in paragraph tags when needed
-            if (!formatted.startsWith('<h4>') && !formatted.startsWith('<ul>')) {
-                formatted = '<p>' + formatted;
-            }
-            if (!formatted.endsWith('</p>') && !formatted.endsWith('</ul>')) {
-                formatted = formatted + '</p>';
-            }
-
-            console.log('Formatted text:', formatted);
-            return formatted;
-        }
+        // formatting handled in static/js/app.js
 
         function addMessage(content, sender, isStreaming = false) {
             const messagesArea = document.getElementById('messagesArea');


### PR DESCRIPTION
## Summary
- keep server-side streaming whitespace and newline characters
- render bold text and structured lists on the frontend
- normalize backend answers and add typography styling

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6898e4f675088322865dc88bf3a4b55f